### PR TITLE
Feat: add waiting making controller

### DIFF
--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -1,0 +1,9 @@
+package likelion.festival.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+}

--- a/src/main/java/likelion/festival/controller/LoginController.java
+++ b/src/main/java/likelion/festival/controller/LoginController.java
@@ -1,0 +1,31 @@
+package likelion.festival.controller;
+
+import likelion.festival.dto.AuthCodeRequestDto;
+import likelion.festival.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+//@RestController
+//@RequiredArgsConstructor
+//public class LoginController {
+//    private final UserService userService;
+//
+//    /* 프론트에서 로그인 하고 받은 응답 코드 받는 메서드*/
+//    @GetMapping("/login/kakao/auth-code")
+//    public ResponseEntity<String> getAuthCode(@ModelAttribute AuthCodeRequestDto authCodeResponseDto){
+//
+//        if (authCodeResponseDto.getError() != null) {
+//            URI redirectUri = URI.create("https://{frontend.com}/login?error=" + URLEncoder.encode(authCodeResponseDto.getError_description(), StandardCharsets.UTF_8));
+//            return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
+//        }
+//
+//
+//
+//    }
+//}

--- a/src/main/java/likelion/festival/controller/WaitingController.java
+++ b/src/main/java/likelion/festival/controller/WaitingController.java
@@ -1,0 +1,28 @@
+package likelion.festival.controller;
+
+import likelion.festival.domain.User;
+import likelion.festival.domain.Waiting;
+import likelion.festival.dto.WaitingRequestDto;
+import likelion.festival.dto.WaitingResponseDto;
+import likelion.festival.service.UserService;
+import likelion.festival.service.WaitingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class WaitingController {
+    private final WaitingService waitingService;
+    private final UserService userService;
+
+    @PostMapping("/api/waitings")
+    public WaitingResponseDto makeWaiting(@RequestBody WaitingRequestDto waitingRequestDto) {
+        User user = userService.getUserById(waitingRequestDto.getUserId());
+
+        return waitingService.addWaiting(user, waitingRequestDto);
+    }
+}

--- a/src/main/java/likelion/festival/domain/LostItem.java
+++ b/src/main/java/likelion/festival/domain/LostItem.java
@@ -2,11 +2,13 @@ package likelion.festival.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class LostItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/festival/domain/Pub.java
+++ b/src/main/java/likelion/festival/domain/Pub.java
@@ -2,11 +2,13 @@ package likelion.festival.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Pub {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,6 +17,10 @@ public class Pub {
     private String host;
 
     private Long likeCount;
+
+    private Integer enterNum;
+
+    private Integer waitingNum;
 
     @OneToMany(mappedBy = "pub", cascade = CascadeType.REMOVE)
     private List<Waiting> waitingList;

--- a/src/main/java/likelion/festival/domain/User.java
+++ b/src/main/java/likelion/festival/domain/User.java
@@ -2,12 +2,14 @@ package likelion.festival.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/festival/domain/Waiting.java
+++ b/src/main/java/likelion/festival/domain/Waiting.java
@@ -3,11 +3,13 @@ package likelion.festival.domain;
 import jakarta.persistence.*;
 import likelion.festival.enums.WaitingStatus;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Waiting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,6 +24,10 @@ public class Waiting {
 
     private String phoneNumber;
 
+    private String pubName;
+
+    private Integer waitingNum;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -29,4 +35,15 @@ public class Waiting {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pub_id")
     private Pub pub;
+
+    public Waiting(Long visitorCount, String phoneNumber, String pubName, Integer waitingNum, User user, Pub pub) {
+        this.visitorCount = visitorCount;
+        this.phoneNumber = phoneNumber;
+        this.pubName = pubName;
+        this.waitingNum = waitingNum;
+        this.createdAt = LocalDateTime.now();
+        this.waitingStatus = WaitingStatus.Wait;
+        this.user = user;
+        this.pub = pub;
+    }
 }

--- a/src/main/java/likelion/festival/dto/AuthCodeRequestDto.java
+++ b/src/main/java/likelion/festival/dto/AuthCodeRequestDto.java
@@ -1,0 +1,13 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthCodeRequestDto {
+    private String code;
+    private String error;
+    private String error_description;
+    private String state;
+}

--- a/src/main/java/likelion/festival/dto/WaitingRequestDto.java
+++ b/src/main/java/likelion/festival/dto/WaitingRequestDto.java
@@ -1,0 +1,18 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class WaitingRequestDto {
+    private Long visitorCount;
+
+    private String phoneNumber;
+
+    private String pubName;
+
+    private Long pubId;
+
+    private Long userId;
+}

--- a/src/main/java/likelion/festival/dto/WaitingResponseDto.java
+++ b/src/main/java/likelion/festival/dto/WaitingResponseDto.java
@@ -1,0 +1,11 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class WaitingResponseDto {
+    private Integer waitingNum;
+    private Integer numsTeamsAhead;
+}

--- a/src/main/java/likelion/festival/exceptions/PubNotFoundException.java
+++ b/src/main/java/likelion/festival/exceptions/PubNotFoundException.java
@@ -1,0 +1,7 @@
+package likelion.festival.exceptions;
+
+public class PubNotFoundException extends RuntimeException{
+    public PubNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/exceptions/UserNotFoundException.java
+++ b/src/main/java/likelion/festival/exceptions/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package likelion.festival.exceptions;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/repository/PubRepository.java
+++ b/src/main/java/likelion/festival/repository/PubRepository.java
@@ -1,0 +1,7 @@
+package likelion.festival.repository;
+
+import likelion.festival.domain.Pub;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PubRepository extends JpaRepository<Pub, Long> {
+}

--- a/src/main/java/likelion/festival/repository/UserRepository.java
+++ b/src/main/java/likelion/festival/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package likelion.festival.repository;
+
+import likelion.festival.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/likelion/festival/repository/WaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/WaitingRepository.java
@@ -1,0 +1,7 @@
+package likelion.festival.repository;
+
+import likelion.festival.domain.Waiting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+}

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -1,0 +1,19 @@
+package likelion.festival.service;
+
+import likelion.festival.domain.Pub;
+import likelion.festival.repository.PubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PubService {
+    private final PubRepository pubRepository;
+
+    @Transactional
+    public Pub getPubById(Long id) {
+        return pubRepository.findById(id).orElseThrow();
+    }
+}

--- a/src/main/java/likelion/festival/service/UserService.java
+++ b/src/main/java/likelion/festival/service/UserService.java
@@ -1,0 +1,20 @@
+package likelion.festival.service;
+
+import likelion.festival.domain.User;
+import likelion.festival.exceptions.UserNotFoundException;
+import likelion.festival.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly=true)
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User getUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException("Connot find user with given id"));
+    }
+}

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -1,0 +1,55 @@
+package likelion.festival.service;
+
+import likelion.festival.domain.Pub;
+import likelion.festival.domain.User;
+import likelion.festival.domain.Waiting;
+import likelion.festival.dto.WaitingRequestDto;
+import likelion.festival.dto.WaitingResponseDto;
+import likelion.festival.repository.WaitingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class WaitingService {
+    private final WaitingRepository waitingRepository;
+    private final PubService pubService;
+
+    @Transactional
+    public WaitingResponseDto addWaiting(User user, WaitingRequestDto waitingRequestDto) {
+        List<Waiting> waitingList = user.getWaitingList();
+        if (waitingList.size() > 3) {
+            throw new IllegalArgumentException("");
+        }
+
+        Pub pub = pubService.getPubById(waitingRequestDto.getPubId());
+        validateDuplicatedWaiting(waitingList, pub);
+
+
+        Waiting waiting = save(waitingRequestDto, pub.getWaitingNum() + 1, user, pub);
+        return new WaitingResponseDto(waiting.getWaitingNum(),
+                pub.getWaitingNum() - pub.getEnterNum()
+        );
+    }
+
+    @Transactional
+    public Waiting save(WaitingRequestDto waitingRequestDto, Integer waitingNum, User user, Pub pub) {
+        return waitingRepository.save(new Waiting(waitingRequestDto.getVisitorCount(),
+                waitingRequestDto.getPhoneNumber(),
+                waitingRequestDto.getPubName(),
+                waitingNum,
+                user,
+                pub));
+    }
+
+    private void validateDuplicatedWaiting(List<Waiting> waitingList, Pub pub) {
+        if (waitingList.stream()
+                .anyMatch(waiting -> waiting.getPub().equals(pub))) {
+            throw new RuntimeException("이미 해당 주점에 대한 대기열이 존재합니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Feat: 웨이팅 추가하는 컨트롤러


---

## 📝 변경사항
- 웨이팅 추가하는 컨트롤러 만들었습니다
- 그리고 예약 번호, 입장 번호를 위해서 pub 엔티티랑 waiting 엔티티에 컬럼을 추가했습니다.
- 예약 번호, 입장 번호 동작 방식은 추후 논의가 좀 필요할 것 같기는 한데 일단 대충 짜봤습니다

---

## 🔍 테스트 방법
- 아직은 테스트 코드 없어서 postman으로

---

## 💬 기타 참고사항
- 리팩터링이 필요해보이는 코드들이 좀 보이는데, 많이 거슬리기는 한데 얼른 기능 구현부터 하고 리팩터링은 추후에 진행하겠습니다.
- 로그인 구현하는데 스프링 시큐리티 코드 건드리다가 시간이 너무 많이 걸릴 것 같아서 일단 웨이팅부터 작업했습니다