### PR TITLE
로그인 오류 수정 + 토큰 리프레쉬 컨트롤러 추가

### DIFF
--- a/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
+++ b/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import likelion.festival.utils.JwtTokenUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,15 +18,26 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenUtils jwtTokenUtils;
     private final UserDetailsService userDetailsService;
+    String[] WHITELIST = SecurityConfig.WHITELIST;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+
+        for (String string : WHITELIST) {
+            if (path.startsWith(string)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
 
         String token = resolveToken(request);
 
@@ -49,7 +61,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (bearer != null && bearer.startsWith("Bearer ")) {
             return bearer.substring(7);
         }
-        throw new RuntimeException("token is invalid");
+        log.info(request.getRequestURI());
+        log.info(request.getMethod());
+        throw new RuntimeException("token is invalid or null");
     }
 }
 

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -16,6 +16,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    public static final String[] WHITELIST = {
+            "/auth/login/kakao/auth-code",
+            "/error",
+            "/admin/waiting",
+            "/auth/refresh"
+    };
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -23,7 +29,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/auth/login/kakao/**", "/error", "admin/waiting", "/auth/refresh").permitAll()
+                        .requestMatchers(WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 )
                 .cors(cors -> cors

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/auth/login/kakao/**", "/error", "admin/waiting").permitAll()
+                        .requestMatchers("/auth/login/kakao/**", "/error", "admin/waiting", "/auth/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
                 .cors(cors -> cors

--- a/src/main/java/likelion/festival/controller/AuthController.java
+++ b/src/main/java/likelion/festival/controller/AuthController.java
@@ -1,8 +1,13 @@
 package likelion.festival.controller;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import likelion.festival.domain.User;
 import likelion.festival.dto.AuthCodeRequestDto;
 import likelion.festival.service.AuthService;
+import likelion.festival.service.UserService;
+import likelion.festival.utils.JwtTokenUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +21,8 @@ import java.nio.charset.StandardCharsets;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final UserService userService;
+    private final JwtTokenUtils jwtTokenUtils;
 
     @GetMapping("/auth/login/kakao/auth-code")
     public ResponseEntity<String> getAuthCode(@ModelAttribute AuthCodeRequestDto authCodeResponseDto, HttpServletResponse response){
@@ -27,5 +34,15 @@ public class AuthController {
 
         authService.doLoginProcess(authCodeResponseDto.getCode(), response);
         return ResponseEntity.ok().body("Login successful");
+    }
+
+    @PostMapping("/auth/refresh")
+    public String refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtTokenUtils.getRefreshToken(request);
+
+        User user = userService.getUserByRefreshToken(refreshToken);
+        String token = jwtTokenUtils.generateAccessToken(user);
+        response.setHeader("Authorization", "Bearer " + token);
+        return "Token refreshed";
     }
 }

--- a/src/main/java/likelion/festival/dto/KakaoUserInfo.java
+++ b/src/main/java/likelion/festival/dto/KakaoUserInfo.java
@@ -1,36 +1,50 @@
 package likelion.festival.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
 public class KakaoUserInfo {
     private Long id;
-    private KakaoAccount kakaoAccount;
+    private KakaoAccount kakao_account;
+    private Properties properties;
 
-
+    @JsonIgnoreProperties(ignoreUnknown = true)
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class KakaoAccount {
         private String email;
         private Profile profile;
+    }
 
-        @Getter
-        @AllArgsConstructor
-        public static class Profile {
-            private String nickname;
-        }
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Profile {
+        private String nickname;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Properties {
+        private String nickname;
     }
 
     public String getEmail() {
-        return kakaoAccount.getEmail();
+        return kakao_account.getEmail();
     }
 
     public String getName() {
-        return kakaoAccount.getProfile().getNickname();
+        return kakao_account.getProfile().getNickname();
     }
 }

--- a/src/main/java/likelion/festival/repository/UserRepository.java
+++ b/src/main/java/likelion/festival/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/likelion/festival/service/AuthService.java
+++ b/src/main/java/likelion/festival/service/AuthService.java
@@ -1,5 +1,7 @@
 package likelion.festival.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import likelion.festival.domain.User;
@@ -7,10 +9,12 @@ import likelion.festival.dto.KakaoUserInfo;
 import likelion.festival.repository.UserRepository;
 import likelion.festival.utils.JwtTokenUtils;
 import likelion.festival.utils.KakaoUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class AuthService {
     private final KakaoUtils kakaoUtils;
     private final UserRepository userRepository;
@@ -36,6 +40,7 @@ public class AuthService {
         String accessToken = kakaoUtils.getAccessToken(code);
 
         KakaoUserInfo userInfo = kakaoUtils.getUserInfo(accessToken);
+
 
         User user = getUserIfNotExistsSignup(userInfo.getEmail(), userInfo.getName());
 

--- a/src/main/java/likelion/festival/service/UserService.java
+++ b/src/main/java/likelion/festival/service/UserService.java
@@ -2,6 +2,7 @@ package likelion.festival.service;
 
 import likelion.festival.domain.User;
 import likelion.festival.enums.RoleType;
+import likelion.festival.exceptions.JwtTokenException;
 import likelion.festival.exceptions.UserNotFoundException;
 import likelion.festival.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +33,9 @@ public class UserService {
                         .role(RoleType.ROLE_USER)
                         .build()
         );
+    }
+
+    public User getUserByRefreshToken(String refreshToken) {
+        return userRepository.findByRefreshToken(refreshToken).orElseThrow(() -> new JwtTokenException("Refresh token not found"));
     }
 }

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -2,6 +2,8 @@ package likelion.festival.utils;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import likelion.festival.domain.User;
 import likelion.festival.exceptions.JwtTokenException;
 import org.springframework.beans.factory.annotation.Value;
@@ -53,6 +55,20 @@ public class JwtTokenUtils {
                 .compact();
     }
 
+    public String getRefreshToken(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("refresh_token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+
+        return null;
+    }
+
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
@@ -63,7 +79,7 @@ public class JwtTokenUtils {
         } catch (SecurityException | MalformedJwtException e) {
             throw new JwtTokenException("Invalid JWT token");
         } catch (ExpiredJwtException e) {
-            throw new JwtTokenException("Expired JWT token");
+            throw new JwtTokenException("Expired");
         } catch (UnsupportedJwtException e) {
             throw new JwtTokenException("Unsupported JWT token");
         } catch (IllegalArgumentException e) {

--- a/src/main/java/likelion/festival/utils/KakaoUtils.java
+++ b/src/main/java/likelion/festival/utils/KakaoUtils.java
@@ -2,6 +2,7 @@ package likelion.festival.utils;
 
 import likelion.festival.dto.KakaoUserInfo;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import java.util.Map;
 
 @Component
 @Getter
+@Slf4j
 public class KakaoUtils {
     @Value("${kakao.auth.client}")
     private String clientId;


### PR DESCRIPTION
## 📌로그인 오류 수정 + 토큰 리프레쉬 컨트롤러 추가


---

## 📝 변경사항
- 필터가 수락되어야 하는 요청도 막아버리는 오류가 생겨서 whitelist를 만들어서 그 경로는 막지 않게 했습니다
- 그리고 카카오의 요청을 받는 기존 dto가 실제 로그인하고 받는 JSON 응답 데이터의 형식과 일치하지 않아 수정했습니다
- 그리고 토큰이 만료되면 401 에러를 던졌었는데, 그러면 쿠키의 리프레시 토큰으로 재발급을 요청하는 API를 추가했습니다.

---

## 🔍 테스트 방법
- Postman

---

## 💬 기타 참고사항