### PR TITLE
분실물 조회와 등록, 주점 목록 조회와 좋아요 증가 api 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 .vscode/
 
 /src/main/resources/*.properties
+/src/main/resources/*.yml

--- a/src/main/java/likelion/festival/controller/LostItemController.java
+++ b/src/main/java/likelion/festival/controller/LostItemController.java
@@ -7,6 +7,7 @@ import likelion.festival.service.LostItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URI;
 import java.util.List;
@@ -31,8 +32,10 @@ public class LostItemController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> addLostItem(@RequestBody LostItemRequestDto dto) {
-        LostItem lostItem = lostItemService.addLostItem(dto);
+    public ResponseEntity<Void> addLostItem(@RequestPart("data") LostItemRequestDto dto, @RequestPart("image") MultipartFile image) {
+        System.out.println(dto);
+
+        LostItem lostItem = lostItemService.addLostItem(dto, image);
         URI location =URI.create("/api/lost-items/" + lostItem.getId());
         return ResponseEntity.created(location).build();
     }

--- a/src/main/java/likelion/festival/controller/LostItemController.java
+++ b/src/main/java/likelion/festival/controller/LostItemController.java
@@ -1,10 +1,14 @@
 package likelion.festival.controller;
 
+import likelion.festival.domain.LostItem;
 import likelion.festival.dto.LostItemListResponseDto;
+import likelion.festival.dto.LostItemRequestDto;
 import likelion.festival.service.LostItemService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -15,12 +19,21 @@ public class LostItemController {
     private final LostItemService lostItemService;
 
     @GetMapping
-    public List<LostItemListResponseDto> getLostItems(@RequestParam String lostDate, @RequestParam(required = false) String name) {
-        if (name == null || name.isBlank()) { // 모든 분실물을 반환
-            return lostItemService.findByLostDate(lostDate);
-        } else {
-            return lostItemService.findByLostDateAndName(lostDate, name);
-        }
+    public ResponseEntity<List<LostItemListResponseDto>> getLostItems(@RequestParam String lostDate, @RequestParam(required = false) String name) {
+        List<LostItemListResponseDto>lostItems;
 
+        if (name == null || name.isBlank()) { // 모든 분실물을 반환
+            lostItems = lostItemService.findByLostDate(lostDate);
+        } else {
+            lostItems = lostItemService.findByLostDateAndName(lostDate, name);
+        }
+        return ResponseEntity.ok(lostItems);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> addLostItem(@RequestBody LostItemRequestDto dto) {
+        LostItem lostItem = lostItemService.addLostItem(dto);
+        URI location =URI.create("/api/lost-items/" + lostItem.getId());
+        return ResponseEntity.created(location).build();
     }
 }

--- a/src/main/java/likelion/festival/controller/LostItemController.java
+++ b/src/main/java/likelion/festival/controller/LostItemController.java
@@ -1,0 +1,26 @@
+package likelion.festival.controller;
+
+import likelion.festival.dto.LostItemListResponseDto;
+import likelion.festival.service.LostItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lost-items")
+public class LostItemController {
+
+    private final LostItemService lostItemService;
+
+    @GetMapping
+    public List<LostItemListResponseDto> getLostItems(@RequestParam String lostDate, @RequestParam(required = false) String name) {
+        if (name == null || name.isBlank()) { // 모든 분실물을 반환
+            return lostItemService.findByLostDate(lostDate);
+        } else {
+            return lostItemService.findByLostDateAndName(lostDate, name);
+        }
+
+    }
+}

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -1,0 +1,30 @@
+package likelion.festival.controller;
+
+import likelion.festival.dto.PubRequestDto;
+import likelion.festival.dto.PubResponseDto;
+import likelion.festival.service.PubService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/pubs")
+public class PubController {
+
+    private final PubService pubService;
+
+    @GetMapping
+    public ResponseEntity<List<PubResponseDto>> getPubs() {
+        List<PubResponseDto> pubs = pubService.getPubRanks();
+        return ResponseEntity.ok(pubs);
+    }
+
+    @PostMapping("{PubId}/likes")
+    public ResponseEntity<Void> addLike(@PathVariable Long pubId, @RequestBody PubRequestDto dto) {
+        pubService.addPubLike(pubId, dto.getAddCount());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/likelion/festival/domain/LostItem.java
+++ b/src/main/java/likelion/festival/domain/LostItem.java
@@ -24,6 +24,8 @@ public class LostItem {
 
     private String foundLocation;
 
+    private String foundDate;
+
     private String foundTime;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/likelion/festival/domain/LostItem.java
+++ b/src/main/java/likelion/festival/domain/LostItem.java
@@ -29,7 +29,7 @@ public class LostItem {
     private String foundTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = true)
     private User user;
 
     public LostItem(

--- a/src/main/java/likelion/festival/domain/LostItem.java
+++ b/src/main/java/likelion/festival/domain/LostItem.java
@@ -31,4 +31,25 @@ public class LostItem {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public LostItem(
+            String image,
+            String name,
+            String description,
+            Boolean staffNotified,
+            String foundLocation,
+            String foundDate,
+            String foundTime,
+            User user
+    ) {
+        this.image = image;
+        this.name = name;
+        this.description = description;
+        this.staffNotified = staffNotified;
+        this.foundLocation = foundLocation;
+        this.foundDate = foundDate;
+        this.foundTime = foundTime;
+        this.user = user;
+    }
 }
+

--- a/src/main/java/likelion/festival/domain/Pub.java
+++ b/src/main/java/likelion/festival/domain/Pub.java
@@ -24,4 +24,8 @@ public class Pub {
 
     @OneToMany(mappedBy = "pub", cascade = CascadeType.REMOVE)
     private List<Waiting> waitingList;
+
+    public void addLikeCount(Long addCount) {
+        this.likeCount += addCount;
+    }
 }

--- a/src/main/java/likelion/festival/dto/LostItemDetailResponseDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemDetailResponseDto.java
@@ -11,16 +11,13 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class LostItemResponseDto {
+public class LostItemDetailResponseDto {
     private Long id;
     private String image;
     private String name;
     private String description;
     private Boolean staffNotified;
     private String foundLocation;
-    private LocalDateTime foundTime;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    private String foundDate;
+    private String foundTime;
 }

--- a/src/main/java/likelion/festival/dto/LostItemDetailResponseDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemDetailResponseDto.java
@@ -1,30 +1,24 @@
-package likelion.festival.domain;
+package likelion.festival.dto;
 
-import jakarta.persistence.*;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import likelion.festival.domain.User;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Entity
 @Getter
-@NoArgsConstructor
-public class LostItem {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+@AllArgsConstructor
+public class LostItemResponseDto {
     private Long id;
-
     private String image;
-
     private String name;
-
     private String description;
-
     private Boolean staffNotified;
-
     private String foundLocation;
-
-    private String foundTime;
+    private LocalDateTime foundTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/likelion/festival/dto/LostItemListResponseDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemListResponseDto.java
@@ -1,0 +1,17 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class LostItemListResponseDto {
+    private Long id;
+    private String image;
+    private String name;
+    private Boolean staffNotified;
+    private String foundLocation;
+    private String foundDate;
+}

--- a/src/main/java/likelion/festival/dto/LostItemListResponseDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemListResponseDto.java
@@ -1,12 +1,12 @@
 package likelion.festival.dto;
 
+import likelion.festival.domain.LostItem;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 public class LostItemListResponseDto {
     private Long id;
     private String image;
@@ -14,4 +14,13 @@ public class LostItemListResponseDto {
     private Boolean staffNotified;
     private String foundLocation;
     private String foundDate;
+
+    public LostItemListResponseDto(LostItem entity) {
+        this.id = entity.getId();
+        this.image = entity.getImage();
+        this.name = entity.getName();
+        this.staffNotified = entity.getStaffNotified();
+        this.foundLocation = entity.getFoundLocation();
+        this.foundDate = entity.getFoundDate();
+    }
 }

--- a/src/main/java/likelion/festival/dto/LostItemRequestDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemRequestDto.java
@@ -20,10 +20,4 @@ public class LostItemRequestDto {
     private String foundDate;
     private String foundTime;
     private Long userId;
-
-    public LostItem save() {
-        return new LostItem(
-                this.name
-        );
-    }
 }

--- a/src/main/java/likelion/festival/dto/LostItemRequestDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemRequestDto.java
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @AllArgsConstructor
 public class LostItemRequestDto {
-    private MultipartFile image;
+    //private MultipartFile image;
     private String name;
     private String description;
     private Boolean staffNotified;

--- a/src/main/java/likelion/festival/dto/LostItemRequestDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemRequestDto.java
@@ -1,0 +1,29 @@
+package likelion.festival.dto;
+
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import likelion.festival.domain.LostItem;
+import likelion.festival.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+public class LostItemRequestDto {
+    private MultipartFile image;
+    private String name;
+    private String description;
+    private Boolean staffNotified;
+    private String foundLocation;
+    private String foundDate;
+    private String foundTime;
+    private Long userId;
+
+    public LostItem save() {
+        return new LostItem(
+                this.name
+        );
+    }
+}

--- a/src/main/java/likelion/festival/dto/PubRequestDto.java
+++ b/src/main/java/likelion/festival/dto/PubRequestDto.java
@@ -1,0 +1,8 @@
+package likelion.festival.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PubRequestDto {
+    private Long addCount;
+}

--- a/src/main/java/likelion/festival/dto/PubResponseDto.java
+++ b/src/main/java/likelion/festival/dto/PubResponseDto.java
@@ -1,0 +1,15 @@
+package likelion.festival.dto;
+
+import likelion.festival.domain.Pub;
+import lombok.Getter;
+
+@Getter
+public class PubResponseDto {
+    private Long id;
+    private Long likeCount;
+
+    public PubResponseDto(Pub pub) {
+        this.id = pub.getId();
+        this.likeCount = pub.getLikeCount();
+    }
+}

--- a/src/main/java/likelion/festival/repository/LostItemRepository.java
+++ b/src/main/java/likelion/festival/repository/LostItemRepository.java
@@ -1,0 +1,7 @@
+package likelion.festival.repository;
+
+import likelion.festival.domain.LostItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LostItemRepository extends JpaRepository<LostItem, Long> {
+}

--- a/src/main/java/likelion/festival/repository/LostItemRepository.java
+++ b/src/main/java/likelion/festival/repository/LostItemRepository.java
@@ -3,5 +3,10 @@ package likelion.festival.repository;
 import likelion.festival.domain.LostItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
+    List<LostItem> findByLostDate(String lostDate);
+
+    List<LostItem> findByLostDateAndNameContaining(String lostDate, String name);
 }

--- a/src/main/java/likelion/festival/repository/LostItemRepository.java
+++ b/src/main/java/likelion/festival/repository/LostItemRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface LostItemRepository extends JpaRepository<LostItem, Long> {
-    List<LostItem> findByLostDate(String lostDate);
+    List<LostItem> findByFoundDate(String lostDate);
 
-    List<LostItem> findByLostDateAndNameContaining(String lostDate, String name);
+    List<LostItem> findByFoundDateAndNameContaining(String lostDate, String name);
 }

--- a/src/main/java/likelion/festival/repository/PubRepository.java
+++ b/src/main/java/likelion/festival/repository/PubRepository.java
@@ -3,5 +3,8 @@ package likelion.festival.repository;
 import likelion.festival.domain.Pub;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PubRepository extends JpaRepository<Pub, Long> {
+    List<Pub> findAllByOrderByLikeCountDesc();
 }

--- a/src/main/java/likelion/festival/service/ImageService.java
+++ b/src/main/java/likelion/festival/service/ImageService.java
@@ -1,0 +1,47 @@
+package likelion.festival.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+public class ImageService {
+    private final String uploadDir = System.getProperty("user.dir") + "/uploads/";
+    private final String baseUrl = "/images/";
+
+    public String saveImage(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        try {
+            String originalFilename = file.getOriginalFilename();
+            String filename = UUID.randomUUID() + "_" + originalFilename;
+            Path savePath = Paths.get(uploadDir, filename);
+
+            Files.createDirectories(savePath.getParent());
+            file.transferTo(savePath);
+
+            return baseUrl + filename;
+
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 저장 실패");
+        }
+    }
+
+    private String getExtension(String originalFilename) {
+        if (originalFilename == null || originalFilename.isBlank()) {
+            throw new IllegalArgumentException("원본 파일 이름이 null입니다.");
+        }
+        int dotIndex = originalFilename.lastIndexOf('.');
+        if (dotIndex == -1) {
+            return ""; // 확장자가 없는 경우
+        }
+        return originalFilename.substring(dotIndex); // 예: ".jpg"
+    }
+}

--- a/src/main/java/likelion/festival/service/LostItemService.java
+++ b/src/main/java/likelion/festival/service/LostItemService.java
@@ -36,7 +36,7 @@ public class LostItemService {
     @Transactional
     public LostItem addLostItem(LostItemRequestDto dto) {
         User user = userRepository.findById(dto.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElse(null);
 
         String imageUrl = imageService.saveImage(dto.getImage());
 

--- a/src/main/java/likelion/festival/service/LostItemService.java
+++ b/src/main/java/likelion/festival/service/LostItemService.java
@@ -17,13 +17,13 @@ public class LostItemService {
     private final LostItemRepository lostItemRepository;
 
     public List<LostItemListResponseDto> findByLostDate(String lostDate) {
-        List<LostItem> lostItems = lostItemRepository.findByLostDate(lostDate);
+        List<LostItem> lostItems = lostItemRepository.findByFoundDate(lostDate);
         return lostItems.stream().map(lostItem -> new LostItemListResponseDto(lostItem))
                 .toList();
     }
 
     public List<LostItemListResponseDto> findByLostDateAndName(String lostDate, String name) {
-        List<LostItem> lostItems = lostItemRepository.findByLostDateAndNameContaining(lostDate, name);
+        List<LostItem> lostItems = lostItemRepository.findByFoundDateAndNameContaining(lostDate, name);
         return lostItems.stream().map(lostItem -> new LostItemListResponseDto(lostItem))
                 .toList();
     }

--- a/src/main/java/likelion/festival/service/LostItemService.java
+++ b/src/main/java/likelion/festival/service/LostItemService.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -34,11 +35,11 @@ public class LostItemService {
     }
 
     @Transactional
-    public LostItem addLostItem(LostItemRequestDto dto) {
+    public LostItem addLostItem(LostItemRequestDto dto, MultipartFile image) {
         User user = userRepository.findById(dto.getUserId())
                 .orElse(null);
 
-        String imageUrl = imageService.saveImage(dto.getImage());
+        String imageUrl = imageService.saveImage(image);
 
         LostItem lostItem = new LostItem(
                 imageUrl,

--- a/src/main/java/likelion/festival/service/LostItemService.java
+++ b/src/main/java/likelion/festival/service/LostItemService.java
@@ -1,8 +1,11 @@
 package likelion.festival.service;
 
 import likelion.festival.domain.LostItem;
+import likelion.festival.domain.User;
 import likelion.festival.dto.LostItemListResponseDto;
+import likelion.festival.dto.LostItemRequestDto;
 import likelion.festival.repository.LostItemRepository;
+import likelion.festival.repository.UserRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +18,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LostItemService {
     private final LostItemRepository lostItemRepository;
+    private final UserRepository userRepository;
+    private final ImageService imageService;
 
     public List<LostItemListResponseDto> findByLostDate(String lostDate) {
         List<LostItem> lostItems = lostItemRepository.findByFoundDate(lostDate);
@@ -26,5 +31,27 @@ public class LostItemService {
         List<LostItem> lostItems = lostItemRepository.findByFoundDateAndNameContaining(lostDate, name);
         return lostItems.stream().map(lostItem -> new LostItemListResponseDto(lostItem))
                 .toList();
+    }
+
+    @Transactional
+    public LostItem addLostItem(LostItemRequestDto dto) {
+        User user = userRepository.findById(dto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        String imageUrl = imageService.saveImage(dto.getImage());
+
+        LostItem lostItem = new LostItem(
+                imageUrl,
+                dto.getName(),
+                dto.getDescription(),
+                dto.getStaffNotified(),
+                dto.getFoundLocation(),
+                dto.getFoundDate(),
+                dto.getFoundTime(),
+                user
+        );
+
+        LostItem savedLostItem = lostItemRepository.save(lostItem);
+        return savedLostItem;
     }
 }

--- a/src/main/java/likelion/festival/service/LostItemService.java
+++ b/src/main/java/likelion/festival/service/LostItemService.java
@@ -1,0 +1,30 @@
+package likelion.festival.service;
+
+import likelion.festival.domain.LostItem;
+import likelion.festival.dto.LostItemListResponseDto;
+import likelion.festival.repository.LostItemRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LostItemService {
+    private final LostItemRepository lostItemRepository;
+
+    public List<LostItemListResponseDto> findByLostDate(String lostDate) {
+        List<LostItem> lostItems = lostItemRepository.findByLostDate(lostDate);
+        return lostItems.stream().map(lostItem -> new LostItemListResponseDto(lostItem))
+                .toList();
+    }
+
+    public List<LostItemListResponseDto> findByLostDateAndName(String lostDate, String name) {
+        List<LostItem> lostItems = lostItemRepository.findByLostDateAndNameContaining(lostDate, name);
+        return lostItems.stream().map(lostItem -> new LostItemListResponseDto(lostItem))
+                .toList();
+    }
+}

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -1,10 +1,13 @@
 package likelion.festival.service;
 
 import likelion.festival.domain.Pub;
+import likelion.festival.dto.PubResponseDto;
 import likelion.festival.repository.PubRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -15,5 +18,18 @@ public class PubService {
     @Transactional
     public Pub getPubById(Long id) {
         return pubRepository.findById(id).orElseThrow();
+    }
+
+    public List<PubResponseDto> getPubRanks() {
+        List<Pub> pubs = pubRepository.findAllByOrderByLikeCountDesc();
+        return pubs.stream().map(pub -> new PubResponseDto(pub))
+                .toList();
+    }
+
+    @Transactional
+    public void addPubLike(Long pubId, Long addCount) {
+        Pub pub = pubRepository.findById(pubId)
+                .orElseThrow();
+        pub.addLikeCount(addCount);
     }
 }


### PR DESCRIPTION
## 📌 분실물 조회와 등록, 주점 목록 조회와 좋아요 증가 api 추가


---

## 📝 변경사항
- 축제 날짜별로 분실물 조회
- 분실물 이름 검색
- 주점 랭킹 순위 조회
- 주점 좋아요 개수 증가

---

## 🔍 테스트 방법
- 테스트를 위해서는 로그인 이후, 토큰을 발급 받아야 가능 
- Postman 사용

---

## 💬 기타 참고사항