### PR TITLE
분실물 등록 시, userId 전달 받지 않도록 수정

### DIFF
--- a/src/main/java/likelion/festival/domain/LostItem.java
+++ b/src/main/java/likelion/festival/domain/LostItem.java
@@ -28,9 +28,9 @@ public class LostItem {
 
     private String foundTime;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = true)
-    private User user;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = true)
+//    private User user;
 
     public LostItem(
             String image,
@@ -39,8 +39,7 @@ public class LostItem {
             Boolean staffNotified,
             String foundLocation,
             String foundDate,
-            String foundTime,
-            User user
+            String foundTime
     ) {
         this.image = image;
         this.name = name;
@@ -49,7 +48,6 @@ public class LostItem {
         this.foundLocation = foundLocation;
         this.foundDate = foundDate;
         this.foundTime = foundTime;
-        this.user = user;
     }
 }
 

--- a/src/main/java/likelion/festival/dto/LostItemRequestDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemRequestDto.java
@@ -19,5 +19,5 @@ public class LostItemRequestDto {
     private String foundLocation;
     private String foundDate;
     private String foundTime;
-    private Long userId;
+    //private Long userId;
 }

--- a/src/main/java/likelion/festival/service/LostItemService.java
+++ b/src/main/java/likelion/festival/service/LostItemService.java
@@ -43,8 +43,8 @@ public class LostItemService {
 
     @Transactional
     public LostItem addLostItem(LostItemRequestDto dto, MultipartFile image) {
-        User user = userRepository.findById(dto.getUserId())
-                .orElse(null);
+//        User user = userRepository.findById(dto.getUserId())
+//                .orElse(null);
 
         String imageUrl = imageService.saveImage(image);
 
@@ -55,8 +55,7 @@ public class LostItemService {
                 dto.getStaffNotified(),
                 dto.getFoundLocation(),
                 dto.getFoundDate(),
-                dto.getFoundTime(),
-                user
+                dto.getFoundTime()
         );
 
         LostItem savedLostItem = lostItemRepository.save(lostItem);


### PR DESCRIPTION
## 📌 분실물 등록 시, userId 전달 받지 않도록 수정 (*엔티티 수정)


---

## 📝 변경사항
- LostItem 엔티티 수정 (user 외래키 삭제)
- POST /api/lost-items 요청 본문 수정 (userId 전달 필요 없음)

---

## 🔍 테스트 방법
- postman 사용

---

## 💬 기타 참고사항
- 자세한 내용은 API 명세서 참고!!