### PR TITLE
분실물, 주점 api 테스트 및 분실물 이미지 등록

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 
 /src/main/resources/*.properties
 /src/main/resources/*.yml
+/uploads

--- a/src/main/java/likelion/festival/config/WebConfig.java
+++ b/src/main/java/likelion/festival/config/WebConfig.java
@@ -1,0 +1,15 @@
+package likelion.festival.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**") // 요청 경로
+                .addResourceLocations("file:" + System.getProperty("user.dir") + "/uploads/");
+    }
+}

--- a/src/main/java/likelion/festival/controller/LostItemController.java
+++ b/src/main/java/likelion/festival/controller/LostItemController.java
@@ -1,9 +1,11 @@
 package likelion.festival.controller;
 
+import jakarta.validation.Valid;
 import likelion.festival.domain.LostItem;
 import likelion.festival.dto.LostItemDetailResponseDto;
 import likelion.festival.dto.LostItemListResponseDto;
 import likelion.festival.dto.LostItemRequestDto;
+import likelion.festival.exceptions.MissingImageException;
 import likelion.festival.service.LostItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,11 +41,13 @@ public class LostItemController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> addLostItem(@RequestPart("data") LostItemRequestDto dto, @RequestPart("image") MultipartFile image) {
-        System.out.println(dto);
+    public ResponseEntity<Void> addLostItem(@Valid @RequestPart("data") LostItemRequestDto dto, @RequestPart("image") MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new MissingImageException("분실물 이미지가 첨부되지 않았습니다.");
+        }
 
         LostItem lostItem = lostItemService.addLostItem(dto, image);
-        URI location =URI.create("/api/lost-items/" + lostItem.getId());
+        URI location = URI.create("/api/lost-items/" + lostItem.getId());
         return ResponseEntity.created(location).build();
     }
 }

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -1,5 +1,6 @@
 package likelion.festival.controller;
 
+import jakarta.validation.Valid;
 import likelion.festival.dto.PubRequestDto;
 import likelion.festival.dto.PubResponseDto;
 import likelion.festival.service.PubService;
@@ -23,7 +24,7 @@ public class PubController {
     }
 
     @PostMapping("{pubId}/likes")
-    public ResponseEntity<Void> addLike(@PathVariable Long pubId, @RequestBody PubRequestDto dto) {
+    public ResponseEntity<Void> addLike(@PathVariable Long pubId, @Valid @RequestBody PubRequestDto dto) {
         pubService.addPubLike(pubId, dto.getAddCount());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -22,7 +22,7 @@ public class PubController {
         return ResponseEntity.ok(pubs);
     }
 
-    @PostMapping("{PubId}/likes")
+    @PostMapping("{pubId}/likes")
     public ResponseEntity<Void> addLike(@PathVariable Long pubId, @RequestBody PubRequestDto dto) {
         pubService.addPubLike(pubId, dto.getAddCount());
         return ResponseEntity.noContent().build();

--- a/src/main/java/likelion/festival/domain/User.java
+++ b/src/main/java/likelion/festival/domain/User.java
@@ -30,8 +30,8 @@ public class User {
 
     private String refreshToken;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<LostItem> lostItems = new ArrayList<>();
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+//    private List<LostItem> lostItems = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Waiting> waitingList = new ArrayList<>();

--- a/src/main/java/likelion/festival/dto/ErrorResponse.java
+++ b/src/main/java/likelion/festival/dto/ErrorResponse.java
@@ -1,0 +1,13 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+}

--- a/src/main/java/likelion/festival/dto/LostItemRequestDto.java
+++ b/src/main/java/likelion/festival/dto/LostItemRequestDto.java
@@ -3,6 +3,8 @@ package likelion.festival.dto;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import likelion.festival.domain.LostItem;
 import likelion.festival.domain.User;
 import lombok.AllArgsConstructor;
@@ -13,11 +15,22 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 public class LostItemRequestDto {
     //private MultipartFile image;
+    @NotBlank(message = "name은 필수입니다.")
     private String name;
+
+    @NotBlank(message = "description은 필수입니다.")
     private String description;
+
+    @NotNull(message = "staffNotified은 필수입니다.")
     private Boolean staffNotified;
+
+    @NotBlank(message = "foundLocation은 필수입니다.")
     private String foundLocation;
+
+    @NotBlank(message = "foundDate은 필수입니다.")
     private String foundDate;
+
+    @NotBlank(message = "foundTime은 필수입니다.")
     private String foundTime;
     //private Long userId;
 }

--- a/src/main/java/likelion/festival/dto/PubRequestDto.java
+++ b/src/main/java/likelion/festival/dto/PubRequestDto.java
@@ -1,8 +1,13 @@
 package likelion.festival.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 
 @Getter
 public class PubRequestDto {
+
+    @NotNull(message = "addCount는 필수 필드입니다.")
+    @Positive(message = "addCount는 반드시 양수로 입력해야합니다.")
     private Long addCount;
 }

--- a/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
@@ -3,8 +3,12 @@ package likelion.festival.exceptions;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.lang.reflect.Method;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -31,5 +35,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(WaitingException.class)
     public ResponseEntity<String> handleWaitingException(WaitingException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ":" + error.getDefaultMessage())
+                .reduce((m1, m2) -> m1 + ";" + m2)
+                .orElse("올바르지 않은 요청입니다.");
+
+        return ResponseEntity.badRequest().body(errorMessage);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleJsonBindingError(HttpMessageNotReadableException ex) {
+        return ResponseEntity.badRequest().body("잘못된 JSON 형식입니다. 타입이 올바른지 확인하세요.");
     }
 }

--- a/src/main/java/likelion/festival/exceptions/MissingImageException.java
+++ b/src/main/java/likelion/festival/exceptions/MissingImageException.java
@@ -1,0 +1,7 @@
+package likelion.festival.exceptions;
+
+public class MissingImageException extends RuntimeException {
+    public MissingImageException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/service/ImageService.java
+++ b/src/main/java/likelion/festival/service/ImageService.java
@@ -20,8 +20,8 @@ public class ImageService {
         }
 
         try {
-            String originalFilename = file.getOriginalFilename();
-            String filename = UUID.randomUUID() + "_" + originalFilename;
+            String extension = getExtension(file.getOriginalFilename());
+            String filename = UUID.randomUUID() + "_" + extension;
             Path savePath = Paths.get(uploadDir, filename);
 
             Files.createDirectories(savePath.getParent());


### PR DESCRIPTION
## 📌분실물, 주점 api 테스트 및 분실물 이미지 등록


---

## 📝 변경사항
- LostItemRequestDto, PubRequestDto에 필수 입력 필드 검증 추가
- 분실물 이미지 전달 여부, 분실물 정보 json으로 바인딩 성공 여부 검증 추가
- WebConfig에 분실물 이미지 리소스 매핑 설정 

---

## 🔍 테스트 방법
- postman으로 분실물 api, 주점 api 테스트 진행했습니다.

---

## 💬 기타 참고사항