### PR TITLE
fix: waiting 생성 후, pub의 maxWaitingNum도 1증가

### DIFF
--- a/src/main/java/likelion/festival/domain/Pub.java
+++ b/src/main/java/likelion/festival/domain/Pub.java
@@ -29,7 +29,8 @@ public class Pub {
     private List<GuestWaiting> guestWaitingList;
 
     public Integer addWaitingNum() {
-        return maxWaitingNum + 1;
+        this.maxWaitingNum += 1;
+        return this.maxWaitingNum;
     }
 
     public void addLikeCount(Long addCount) {

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -33,7 +33,8 @@ public class WaitingService {
         validateDuplicatedWaiting(waitingList, pub);
 
 
-        Waiting waiting = save(waitingRequestDto, pub.getMaxWaitingNum() + 1, user, pub);
+
+        Waiting waiting = save(waitingRequestDto, pub.addWaitingNum(), user, pub);
         return new WaitingResponseDto(waiting.getWaitingNum(),
                 pub.getMaxWaitingNum() - pub.getEnterNum()
         );


### PR DESCRIPTION
## 📌 이슈에 적었던 Waiting 생성 로직 문제 수정


---

## 📝 변경사항
- Pub의 addWaitingNum 메소드 수정

---

## 🔍 테스트 방법


---

## 💬 기타 참고사항
