### PR TITLE
웨이팅 삭제 방식 수정

### DIFF
--- a/src/main/java/likelion/festival/controller/AdminController.java
+++ b/src/main/java/likelion/festival/controller/AdminController.java
@@ -19,8 +19,8 @@ public class AdminController {
     private final GuestWaitingService guestWaitingService;
 
     @DeleteMapping("/admin/waiting")
-    public ResponseEntity<String> deleteWaitingByAdmin(@RequestParam Integer waitingNum) {
-        waitingService.deleteWaiting(waitingNum);
+    public ResponseEntity<String> deleteWaitingByAdmin(@RequestParam Long waitingId) {
+        waitingService.deleteWaiting(waitingId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/likelion/festival/controller/WaitingController.java
+++ b/src/main/java/likelion/festival/controller/WaitingController.java
@@ -31,9 +31,9 @@ public class WaitingController {
     }
 
     @DeleteMapping("/api/waitings")
-    public ResponseEntity<String> removeWaiting(@RequestParam Integer waitingNum) {
+    public String removeWaiting(@RequestParam Integer waitingNum) {
         waitingService.deleteWaiting(waitingNum);
-        return ResponseEntity.ok().build();
+        return "Delete Successfully!";
     }
 
     @GetMapping("/api/waitings")

--- a/src/main/java/likelion/festival/controller/WaitingController.java
+++ b/src/main/java/likelion/festival/controller/WaitingController.java
@@ -17,31 +17,35 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/waitings")
 public class WaitingController {
     private final WaitingService waitingService;
     private final UserService userService;
 
-    @PostMapping("/api/waitings")
+    @PostMapping
     public WaitingResponseDto makeWaiting(@RequestBody WaitingRequestDto waitingRequestDto) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        CustomUserDetails userDetails = getRequestUser();
         User user = userService.getUserByEmail(userDetails.getUsername());
 
         return waitingService.addWaiting(user, waitingRequestDto);
     }
 
-    @DeleteMapping("/api/waitings")
-    public String removeWaiting(@RequestParam Integer waitingNum) {
-        waitingService.deleteWaiting(waitingNum);
+    @DeleteMapping
+    public String removeWaiting(@RequestParam Long waitingId) {
+        waitingService.deleteWaiting(waitingId);
         return "Delete Successfully!";
     }
 
-    @GetMapping("/api/waitings")
+    @GetMapping
     public List<MyWaitingList> getWaitingList() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        CustomUserDetails userDetails = getRequestUser();
         User user = userService.getUserByEmail(userDetails.getUsername());
 
         return waitingService.getWaitingList(user);
+    }
+
+    private CustomUserDetails getRequestUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return (CustomUserDetails) authentication.getPrincipal();
     }
 }

--- a/src/main/java/likelion/festival/domain/Waiting.java
+++ b/src/main/java/likelion/festival/domain/Waiting.java
@@ -10,9 +10,6 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "waiting", indexes = {
-        @Index(name = "idx_waiting_num", columnList = "waiting_num")
-})
 public class Waiting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/festival/dto/MyWaitingList.java
+++ b/src/main/java/likelion/festival/dto/MyWaitingList.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class MyWaitingList {
+    private Long waitingId;
     private Integer wholeWaitingNum;
     private Integer numsTeamsAhead;
     private Long pubId;

--- a/src/main/java/likelion/festival/dto/WaitingResponseDto.java
+++ b/src/main/java/likelion/festival/dto/WaitingResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class WaitingResponseDto {
+    private Long id;
     private Integer waitingNum;
     private Integer numsTeamsAhead;
 }

--- a/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package likelion.festival.exceptions;
 
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,9 +17,9 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
     }
 
-    @ExceptionHandler(PubNotFoundException.class)
-    public ResponseEntity<String> handlePubNotFoundException(PubNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    @ExceptionHandler(PubException.class)
+    public ResponseEntity<String> handlePubException(PubException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
     @ExceptionHandler(UserNotFoundException.class)

--- a/src/main/java/likelion/festival/exceptions/PubException.java
+++ b/src/main/java/likelion/festival/exceptions/PubException.java
@@ -1,0 +1,7 @@
+package likelion.festival.exceptions;
+
+public class PubException extends RuntimeException{
+    public PubException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/exceptions/PubNotFoundException.java
+++ b/src/main/java/likelion/festival/exceptions/PubNotFoundException.java
@@ -1,7 +1,0 @@
-package likelion.festival.exceptions;
-
-public class PubNotFoundException extends RuntimeException{
-    public PubNotFoundException(String message){
-        super(message);
-    }
-}

--- a/src/main/java/likelion/festival/repository/WaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/WaitingRepository.java
@@ -9,10 +9,10 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
-    void deleteByWaitingNum(Integer waitingNum);
+    int deleteByWaitingNum(Integer waitingNum);
 
     @Query("SELECT new likelion.festival.dto.MyWaitingList(" +
-            "p.enterNum - p.maxWaitingNum, " +
+            "p.maxWaitingNum - p.enterNum, " +
             "p.enterNum - w.waitingNum, " +
             "p.id, " +
             "w.visitorCount) " +

--- a/src/main/java/likelion/festival/repository/WaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/WaitingRepository.java
@@ -9,9 +9,10 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
-    int deleteByWaitingNum(Integer waitingNum);
+    void deleteById(Long id);
 
     @Query("SELECT new likelion.festival.dto.MyWaitingList(" +
+            "w.id, " +
             "p.maxWaitingNum - p.enterNum, " +
             "p.enterNum - w.waitingNum, " +
             "p.id, " +

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -2,6 +2,7 @@ package likelion.festival.service;
 
 import likelion.festival.domain.Pub;
 import likelion.festival.dto.PubResponseDto;
+import likelion.festival.exceptions.PubException;
 import likelion.festival.repository.PubRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,7 @@ public class PubService {
 
     @Transactional
     public Pub getPubById(Long id) {
-        return pubRepository.findById(id).orElseThrow();
+        return pubRepository.findById(id).orElseThrow(() -> new PubException("No pub with id" + id));
     }
 
     public List<PubResponseDto> getPubRanks() {

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -7,6 +7,7 @@ import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.MyWaitingList;
 import likelion.festival.dto.WaitingRequestDto;
 import likelion.festival.dto.WaitingResponseDto;
+import likelion.festival.exceptions.PubException;
 import likelion.festival.exceptions.WaitingException;
 import likelion.festival.repository.WaitingRepository;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,10 @@ public class WaitingService {
 
     @Transactional
     public void deleteWaiting(Integer waitingNum) {
-        waitingRepository.deleteByWaitingNum(waitingNum);
+        int deletedCount = waitingRepository.deleteByWaitingNum(waitingNum);
+        if (deletedCount == 0) {
+            throw new WaitingException("No waiting found");
+        }
     }
 
     public List<MyWaitingList> getWaitingList(User user) {
@@ -65,7 +69,7 @@ public class WaitingService {
     private void validateDuplicatedWaiting(List<Waiting> waitingList, Pub pub) {
         if (waitingList.stream()
                 .anyMatch(waiting -> waiting.getPub().equals(pub))) {
-            throw new RuntimeException("이미 해당 주점에 대한 대기열이 존재합니다.");
+            throw new PubException("이미 해당 주점에 대한 대기열이 존재합니다.");
         }
     }
 }

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -26,19 +26,16 @@ public class WaitingService {
     @Transactional
     public WaitingResponseDto addWaiting(User user, WaitingRequestDto waitingRequestDto){
         List<Waiting> waitingList = user.getWaitingList();
-        if (waitingList.size() > 3) {
+        if (waitingList.size() == 3) {
             throw new WaitingException("Waiting list is full");
         }
 
         Pub pub = pubService.getPubById(waitingRequestDto.getPubId());
         validateDuplicatedWaiting(waitingList, pub);
 
-
-
         Waiting waiting = save(waitingRequestDto, pub.addWaitingNum(), user, pub);
-        return new WaitingResponseDto(waiting.getWaitingNum(),
-                pub.getMaxWaitingNum() - pub.getEnterNum()
-        );
+        return new WaitingResponseDto(waiting.getId(), waiting.getWaitingNum(),
+                pub.getMaxWaitingNum() - pub.getEnterNum());
     }
 
     @Transactional
@@ -52,11 +49,8 @@ public class WaitingService {
     }
 
     @Transactional
-    public void deleteWaiting(Integer waitingNum) {
-        int deletedCount = waitingRepository.deleteByWaitingNum(waitingNum);
-        if (deletedCount == 0) {
-            throw new WaitingException("No waiting found");
-        }
+    public void deleteWaiting(Long waitingId) {
+        waitingRepository.deleteById(waitingId);
     }
 
     public List<MyWaitingList> getWaitingList(User user) {

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -57,7 +57,7 @@ public class JwtTokenUtils {
 
     public String getRefreshToken(HttpServletRequest request) {
         if (request.getCookies() == null) {
-            return null;
+            throw new JwtTokenException("Token is empty");
         }
 
         for (Cookie cookie : request.getCookies()) {
@@ -66,7 +66,7 @@ public class JwtTokenUtils {
             }
         }
 
-        return null;
+        throw new JwtTokenException("Token is empty");
     }
 
     public boolean validateToken(String token) {


### PR DESCRIPTION
## 📌 웨이팅 삭제 방식 수정


---

## 📝 변경사항
- 웨이팅 삭제 방식 수정
- 그리고 삭제 시 ID를 쓰기 위해 웨이팅 생성과 리스트 요청 API 응답으로 웨이팅 ID 추가

---

## 🔍 테스트 방법
- Postman

---

## 💬 기타 참고사항