### PR TITLE
기존 관리자 컨트롤러가 온라인 예약만 관리하던 문제를 현장 예약도 관리하게 변경

### DIFF
--- a/src/main/java/likelion/festival/controller/AdminController.java
+++ b/src/main/java/likelion/festival/controller/AdminController.java
@@ -1,9 +1,11 @@
 package likelion.festival.controller;
 
 import likelion.festival.domain.GuestWaiting;
+import likelion.festival.dto.AdminDeleteDto;
 import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.GuestWaitingRequestDto;
 import likelion.festival.dto.GuestWaitingResponseDto;
+import likelion.festival.service.AdminService;
 import likelion.festival.service.GuestWaitingService;
 import likelion.festival.service.WaitingService;
 import lombok.RequiredArgsConstructor;
@@ -14,22 +16,23 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/admin/waiting")
 public class AdminController {
-    private final WaitingService waitingService;
     private final GuestWaitingService guestWaitingService;
+    private final AdminService adminService;
 
-    @DeleteMapping("/admin/waiting")
-    public ResponseEntity<String> deleteWaitingByAdmin(@RequestParam Long waitingId) {
-        waitingService.deleteWaiting(waitingId);
-        return ResponseEntity.ok().build();
+    @DeleteMapping
+    public String deleteWaitingByAdmin(@RequestBody AdminDeleteDto adminDeleteDto) {
+        adminService.deleteWaiting(adminDeleteDto);
+        return "Delete Successfully!";
     }
 
-    @GetMapping("/admin/waiting")
+    @GetMapping
     public List<AdminWaitingList> getWaitingList(@RequestParam Long pubId) {
-        return waitingService.getAdminWaitingList(pubId);
+        return adminService.getWaitingList(pubId);
     }
 
-    @PostMapping("/admin/waiting")
+    @PostMapping
     public GuestWaitingResponseDto addGuestWaiting(@RequestBody GuestWaitingRequestDto guestWaitingRequestDto) {
         GuestWaiting guestWaiting = guestWaitingService.addGuestWaiting(guestWaitingRequestDto);
 

--- a/src/main/java/likelion/festival/controller/AuthController.java
+++ b/src/main/java/likelion/festival/controller/AuthController.java
@@ -1,6 +1,5 @@
 package likelion.festival.controller;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import likelion.festival.domain.User;
@@ -39,8 +38,9 @@ public class AuthController {
     @PostMapping("/auth/refresh")
     public String refreshToken(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = jwtTokenUtils.getRefreshToken(request);
+        Long userId = Long.valueOf(jwtTokenUtils.getClaims(refreshToken).getSubject());
 
-        User user = userService.getUserByRefreshToken(refreshToken);
+        User user = userService.getUserById(userId);
         String token = jwtTokenUtils.generateAccessToken(user);
         response.setHeader("Authorization", "Bearer " + token);
         return "Token refreshed";

--- a/src/main/java/likelion/festival/dto/AdminDeleteDto.java
+++ b/src/main/java/likelion/festival/dto/AdminDeleteDto.java
@@ -1,0 +1,11 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AdminDeleteDto {
+    private Long id;
+    private String type;
+}

--- a/src/main/java/likelion/festival/dto/AdminWaitingList.java
+++ b/src/main/java/likelion/festival/dto/AdminWaitingList.java
@@ -10,4 +10,5 @@ public class AdminWaitingList {
     private Integer waitingNum;
     private Integer visitorCount;
     private String phoneNumber;
+    private String type;
 }

--- a/src/main/java/likelion/festival/repository/GuestWaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/GuestWaitingRepository.java
@@ -1,8 +1,21 @@
 package likelion.festival.repository;
 
 import likelion.festival.domain.GuestWaiting;
+import likelion.festival.dto.AdminWaitingList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface GuestWaitingRepository extends JpaRepository<GuestWaiting, Long> {
-
+    @Query("SELECT new likelion.festival.dto.AdminWaitingList(" +
+            "gw.createdAt," +
+            "gw.waitingNum, " +
+            "gw.visitorCount, " +
+            "gw.phoneNumber, " +
+            "'WalkIn')" +
+            "FROM GuestWaiting gw " +
+            "JOIN gw.pub p " +
+            "WHERE gw.pub.id = :pubId")
+    List<AdminWaitingList> findGuestWaitingListByPubId(Long pubId);
 }

--- a/src/main/java/likelion/festival/repository/WaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/WaitingRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
-    void deleteById(Long id);
 
     @Query("SELECT new likelion.festival.dto.MyWaitingList(" +
             "w.id, " +
@@ -26,7 +25,8 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             "w.createdAt," +
             "w.waitingNum, " +
             "w.visitorCount, " +
-            "w.phoneNumber) " +
+            "w.phoneNumber, " +
+            "'Online')" +
             "FROM Waiting w " +
             "JOIN w.pub p " +
             "WHERE w.pub.id = :pubId")

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -1,0 +1,37 @@
+package likelion.festival.service;
+
+import likelion.festival.dto.AdminDeleteDto;
+import likelion.festival.dto.AdminWaitingList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminService {
+    private final WaitingService waitingService;
+    private final GuestWaitingService guestWaitingService;
+
+    public List<AdminWaitingList> getWaitingList(Long pubId) {
+        List<AdminWaitingList> adminWaitingList = new ArrayList<>();
+        adminWaitingList.addAll(waitingService.getAdminWaitingList(pubId));
+        adminWaitingList.addAll(guestWaitingService.getAdminWaitingList(pubId));
+
+        return adminWaitingList;
+    }
+
+    @Transactional
+    public void deleteWaiting(AdminDeleteDto adminDeleteDto) {
+        if (adminDeleteDto.getType().equals("Online")) {
+            waitingService.deleteWaiting(adminDeleteDto.getId());
+        } else if (adminDeleteDto.getType().equals("WalkIn")) {
+            guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
+        } else {
+            throw new RuntimeException("Invalid waiting type");
+        }
+    }
+}

--- a/src/main/java/likelion/festival/service/GuestWaitingService.java
+++ b/src/main/java/likelion/festival/service/GuestWaitingService.java
@@ -2,11 +2,14 @@ package likelion.festival.service;
 
 import likelion.festival.domain.GuestWaiting;
 import likelion.festival.domain.Pub;
+import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.GuestWaitingRequestDto;
 import likelion.festival.repository.GuestWaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,5 +28,14 @@ public class GuestWaitingService {
                         pub.addWaitingNum(),
                         pub)
         );
+    }
+
+    public List<AdminWaitingList> getAdminWaitingList(Long pubId) {
+        return guestWaitingRepository.findGuestWaitingListByPubId(pubId);
+    }
+
+    @Transactional
+    public void deleteGuestWaiting(Long guestWaitingId) {
+        guestWaitingRepository.deleteById(guestWaitingId);
     }
 }


### PR DESCRIPTION
## 📌 관리자 컨트롤러 오류 수정


---

## 📝 변경사항
- 관리자 컨트롤러가 온라인 웨이팅만 다루던 문제를 변경했습니다.
- 그래서 프론트에 각 웨이팅을 보낼 때 type도 저장하게 해서, 온라인 예약과 오프라인 예약을 구분하도록 변경했습니다.
---

## 🔍 테스트 방법
- Postman

---

## 💬 기타 참고사항