### PR TITLE
fcm 알림 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+festival-webapp-firebase-adminsdk-fbsvc-d7a1434630.json
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/likelion/festival/config/FirebaseConfig.java
+++ b/src/main/java/likelion/festival/config/FirebaseConfig.java
@@ -1,0 +1,27 @@
+package likelion.festival.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void initFirebase() throws IOException {
+        FileInputStream serviceAccount = new FileInputStream("festival-webapp-firebase-adminsdk-fbsvc-d7a1434630.json");
+
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(options);
+        }
+    }
+}

--- a/src/main/java/likelion/festival/controller/AdminController.java
+++ b/src/main/java/likelion/festival/controller/AdminController.java
@@ -7,9 +7,7 @@ import likelion.festival.dto.GuestWaitingRequestDto;
 import likelion.festival.dto.GuestWaitingResponseDto;
 import likelion.festival.service.AdminService;
 import likelion.festival.service.GuestWaitingService;
-import likelion.festival.service.WaitingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,10 +19,16 @@ public class AdminController {
     private final GuestWaitingService guestWaitingService;
     private final AdminService adminService;
 
-    @DeleteMapping
-    public String deleteWaitingByAdmin(@RequestBody AdminDeleteDto adminDeleteDto) {
+    @DeleteMapping("/complete")
+    public String completeWaiting(@RequestBody AdminDeleteDto adminDeleteDto) {
+        adminService.completeWaiting(adminDeleteDto);
+        return "complete Successfully!";
+    }
+
+    @DeleteMapping("/no-show")
+    public String deleteWaiting(@RequestBody AdminDeleteDto adminDeleteDto) {
         adminService.deleteWaiting(adminDeleteDto);
-        return "Delete Successfully!";
+        return "delete Successfully!";
     }
 
     @GetMapping

--- a/src/main/java/likelion/festival/controller/FCMController.java
+++ b/src/main/java/likelion/festival/controller/FCMController.java
@@ -1,9 +1,12 @@
 package likelion.festival.controller;
 
 import jakarta.validation.Valid;
+import likelion.festival.domain.User;
+import likelion.festival.domain.Waiting;
 import likelion.festival.dto.FcmTokenRequest;
 import likelion.festival.dto.WaitingAlarmRequest;
 import likelion.festival.service.FCMService;
+import likelion.festival.service.WaitingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class FCMController {
     private final FCMService fcmService;
+    private final WaitingService waitingService;
 
     @PostMapping("{userId}/fcm/token")
     public String getFcmToken(@PathVariable Long userId, @Valid @RequestBody FcmTokenRequest fcmTokenRequest) {
@@ -23,7 +27,9 @@ public class FCMController {
 
     @PostMapping("/waiting/alarm")
     public String sendWaitingAlert(@Valid @RequestBody WaitingAlarmRequest waitingAlarmRequest) {
-        fcmService.sendFcmMessage(waitingAlarmRequest.getToken(),
+        User user = fcmService.getUserByWaitingId(waitingAlarmRequest.getWaitingId(), waitingAlarmRequest.getType());
+
+        fcmService.sendFcmMessage(user.getFcmToken(),
                 "한양대 에리카 봄 축제",
                 waitingAlarmRequest.getPubName() + "의 웨이팅이 얼마 남지 않았습니다. 근처에서 기다려주세요!");
         return "Send FCM Message Successfully";

--- a/src/main/java/likelion/festival/controller/FCMController.java
+++ b/src/main/java/likelion/festival/controller/FCMController.java
@@ -1,0 +1,31 @@
+package likelion.festival.controller;
+
+import jakarta.validation.Valid;
+import likelion.festival.dto.FcmTokenRequest;
+import likelion.festival.dto.WaitingAlarmRequest;
+import likelion.festival.service.FCMService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FCMController {
+    private final FCMService fcmService;
+
+    @PostMapping("{userId}/fcm/token")
+    public String getFcmToken(@PathVariable Long userId, @Valid @RequestBody FcmTokenRequest fcmTokenRequest) {
+        fcmService.saveUserFcmToken(userId, fcmTokenRequest.getToken());
+        return "Save FCM Token Successfully";
+    }
+
+    @PostMapping("/waiting/alarm")
+    public String sendWaitingAlert(@Valid @RequestBody WaitingAlarmRequest waitingAlarmRequest) {
+        fcmService.sendFcmMessage(waitingAlarmRequest.getToken(),
+                "한양대 에리카 봄 축제",
+                waitingAlarmRequest.getPubName() + "의 웨이팅이 얼마 남지 않았습니다. 근처에서 기다려주세요!");
+        return "Send FCM Message Successfully";
+    }
+}

--- a/src/main/java/likelion/festival/domain/User.java
+++ b/src/main/java/likelion/festival/domain/User.java
@@ -30,6 +30,8 @@ public class User {
 
     private String refreshToken;
 
+    private String fcmToken;
+
 //    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
 //    private List<LostItem> lostItems = new ArrayList<>();
 
@@ -38,5 +40,9 @@ public class User {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/likelion/festival/dto/AdminDeleteDto.java
+++ b/src/main/java/likelion/festival/dto/AdminDeleteDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class AdminDeleteDto {
     private Long id;
     private String type;
+    private String fcmToken;
 }

--- a/src/main/java/likelion/festival/dto/AdminWaitingList.java
+++ b/src/main/java/likelion/festival/dto/AdminWaitingList.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 @AllArgsConstructor
 public class AdminWaitingList {
+    private Long id;
     private LocalDateTime createdAt;
     private Integer waitingNum;
     private Integer visitorCount;

--- a/src/main/java/likelion/festival/dto/FcmTokenRequest.java
+++ b/src/main/java/likelion/festival/dto/FcmTokenRequest.java
@@ -1,0 +1,12 @@
+package likelion.festival.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FcmTokenRequest {
+    @NotBlank(message = "토큰 값이 없습니다")
+    private String token;
+}

--- a/src/main/java/likelion/festival/dto/WaitingAlarmRequest.java
+++ b/src/main/java/likelion/festival/dto/WaitingAlarmRequest.java
@@ -7,9 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class WaitingAlarmRequest {
-    @NotBlank(message = "토큰 값이 없습니다")
-    private String token;
-
     @NotBlank(message = "주점 이름이 없습니다")
     private String pubName;
+
+    private Long waitingId;
+
+    private String type;
 }

--- a/src/main/java/likelion/festival/dto/WaitingAlarmRequest.java
+++ b/src/main/java/likelion/festival/dto/WaitingAlarmRequest.java
@@ -1,0 +1,15 @@
+package likelion.festival.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class WaitingAlarmRequest {
+    @NotBlank(message = "토큰 값이 없습니다")
+    private String token;
+
+    @NotBlank(message = "주점 이름이 없습니다")
+    private String pubName;
+}

--- a/src/main/java/likelion/festival/repository/GuestWaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/GuestWaitingRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public interface GuestWaitingRepository extends JpaRepository<GuestWaiting, Long> {
     @Query("SELECT new likelion.festival.dto.AdminWaitingList(" +
+            "gw.id," +
             "gw.createdAt," +
             "gw.waitingNum, " +
             "gw.visitorCount, " +

--- a/src/main/java/likelion/festival/repository/WaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/WaitingRepository.java
@@ -22,6 +22,7 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     List<MyWaitingList> findWaitingListByUserId(Long userId);
 
     @Query("SELECT new likelion.festival.dto.AdminWaitingList(" +
+            "w. id," +
             "w.createdAt," +
             "w.waitingNum, " +
             "w.visitorCount, " +

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -1,7 +1,12 @@
 package likelion.festival.service;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
 import likelion.festival.dto.AdminDeleteDto;
 import likelion.festival.dto.AdminWaitingList;
+import likelion.festival.dto.FcmTokenRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,7 @@ import java.util.List;
 public class AdminService {
     private final WaitingService waitingService;
     private final GuestWaitingService guestWaitingService;
+    private final FCMService fcmService;
 
     public List<AdminWaitingList> getWaitingList(Long pubId) {
         List<AdminWaitingList> adminWaitingList = new ArrayList<>();
@@ -25,13 +31,40 @@ public class AdminService {
     }
 
     @Transactional
-    public void deleteWaiting(AdminDeleteDto adminDeleteDto) {
+    public void completeWaiting(AdminDeleteDto adminDeleteDto) {
         if (adminDeleteDto.getType().equals("Online")) {
             waitingService.deleteWaiting(adminDeleteDto.getId());
+            sendCompleteWaitingMessage(adminDeleteDto.getFcmToken());
         } else if (adminDeleteDto.getType().equals("WalkIn")) {
             guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
+            sendCompleteWaitingMessage(adminDeleteDto.getFcmToken());
         } else {
             throw new RuntimeException("Invalid waiting type");
         }
+    }
+
+    @Transactional
+    public void deleteWaiting(AdminDeleteDto adminDeleteDto) {
+        if (adminDeleteDto.getType().equals("Online")) {
+            waitingService.deleteWaiting(adminDeleteDto.getId());
+            sendDeletedWaitingMessage(adminDeleteDto.getFcmToken());
+        } else if (adminDeleteDto.getType().equals("WalkIn")) {
+            guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
+            sendDeletedWaitingMessage(adminDeleteDto.getFcmToken());
+        } else {
+            throw new RuntimeException("Invalid waiting type");
+        }
+    }
+
+    private void sendCompleteWaitingMessage(String token) {
+        fcmService.sendFcmMessage(token,
+                "한양대 에리카 봄 축제",
+                "주점에 입장하셨습니다. 재밌게 즐겨주세요!");
+    }
+
+    private void sendDeletedWaitingMessage(String token) {
+        fcmService.sendFcmMessage(token,
+                "한양대 에리카 봄 축제",
+                "주점에 노쇼하셔서 웨이팅이 취소되었습니다.");
     }
 }

--- a/src/main/java/likelion/festival/service/FCMService.java
+++ b/src/main/java/likelion/festival/service/FCMService.java
@@ -1,0 +1,39 @@
+package likelion.festival.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import likelion.festival.domain.User;
+import likelion.festival.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly=true)
+@RequiredArgsConstructor
+public class FCMService {
+    private final UserService userService;
+
+    @Transactional
+    public void saveUserFcmToken(Long userId, String fcmToken) {
+        User user = userService.getUserById(userId);
+
+        user.updateFcmToken(fcmToken);
+    }
+
+    public void sendFcmMessage(String token, String title, String body){
+        try {
+            FirebaseMessaging.getInstance().send(Message.builder()
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .setToken(token)
+                    .build());
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/likelion/festival/service/FCMService.java
+++ b/src/main/java/likelion/festival/service/FCMService.java
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import likelion.festival.domain.User;
+import likelion.festival.domain.Waiting;
 import likelion.festival.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,12 +16,22 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FCMService {
     private final UserService userService;
+    private final WaitingService waitingService;
+    private final GuestWaitingService guestWaitingService;
 
     @Transactional
     public void saveUserFcmToken(Long userId, String fcmToken) {
         User user = userService.getUserById(userId);
 
         user.updateFcmToken(fcmToken);
+    }
+
+    public User getUserByWaitingId(Long waitingId, String type) {
+        if (type.equals("Online")) {
+            return waitingService.getWaitingById(waitingId).getUser();
+        } else {
+            throw new RuntimeException("Invalid waiting type");
+        }
     }
 
     public void sendFcmMessage(String token, String title, String body){

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -61,6 +61,11 @@ public class WaitingService {
         return waitingRepository.findWaitingsByPubId(pubId);
     }
 
+    public Waiting getWaitingById(Long waitingId) {
+        return waitingRepository.findById(waitingId).orElseThrow(()
+                -> new WaitingException("Waiting not found"));
+    }
+
     private void validateDuplicatedWaiting(List<Waiting> waitingList, Pub pub) {
         if (waitingList.stream()
                 .anyMatch(waiting -> waiting.getPub().equals(pub))) {


### PR DESCRIPTION
## 📌 fcm 알림 기능 추가


---

## 📝 변경사항
- 관리자가 웨이팅을 노쇼 처리/ 입장 완료 처리 했을 때 사용자에게 FCM 알림이 발송되는 기능
- 프론트에서 웨이팅 순서가 얼마 남지 않았을 때 그 유저에게 알림을 보내는 기능. 이 기능은 온라인 유저에게만 보낼 수 있습니다

---

## 🔍 테스트 방법
- Postman

---

## 💬 기타 참고사항
- 현장 웨이팅인 분들에게는 근처에 와달라는 메시지를 보낼 수 없네요. 