### PR TITLE
관리자 로그인 api 추가

### DIFF
--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -21,7 +21,8 @@ public class SecurityConfig {
             "/error",
             "/admin/waiting",
             "/auth/refresh",
-            "/auth/admin-login"
+            "/auth/admin-login",
+            "/images"
     };
 
     @Bean
@@ -30,6 +31,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/images/**").permitAll()
                         .requestMatchers(WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -20,7 +20,8 @@ public class SecurityConfig {
             "/auth/login/kakao/auth-code",
             "/error",
             "/admin/waiting",
-            "/auth/refresh"
+            "/auth/refresh",
+            "/auth/admin-login"
     };
 
     @Bean

--- a/src/main/java/likelion/festival/controller/AuthController.java
+++ b/src/main/java/likelion/festival/controller/AuthController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import likelion.festival.domain.User;
+import likelion.festival.dto.AdminLoginDto;
 import likelion.festival.dto.AuthCodeRequestDto;
 import likelion.festival.service.AuthService;
 import likelion.festival.service.UserService;
@@ -44,5 +45,11 @@ public class AuthController {
         String token = jwtTokenUtils.generateAccessToken(user);
         response.setHeader("Authorization", "Bearer " + token);
         return "Token refreshed";
+    }
+
+    @PostMapping("/auth/admin-login")
+    public ResponseEntity<String> adminLogin(@RequestBody AdminLoginDto dto, HttpServletResponse response) {
+        authService.adminLogin(dto.getUsername(), dto.getPassword(), response);
+        return ResponseEntity.ok("관리자 로그인이 완료되었습니다.");
     }
 }

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -22,7 +22,7 @@ public class PubController {
         return ResponseEntity.ok(pubs);
     }
 
-    @PostMapping("{PubId}/likes")
+    @PostMapping("{pubId}/likes")
     public ResponseEntity<Void> addLike(@PathVariable Long pubId, @RequestBody PubRequestDto dto) {
         pubService.addPubLike(pubId, dto.getAddCount());
         return ResponseEntity.noContent().build();

--- a/src/main/java/likelion/festival/domain/Pub.java
+++ b/src/main/java/likelion/festival/domain/Pub.java
@@ -14,13 +14,18 @@ public class Pub {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String host;
+    //private String host;
+
+    @Column(unique = true)
+    private String name;
 
     private Long likeCount;
 
     private Integer enterNum;
 
     private Integer maxWaitingNum;
+
+    private String password;
 
     @OneToMany(mappedBy = "pub", cascade = CascadeType.REMOVE)
     private List<Waiting> waitingList;

--- a/src/main/java/likelion/festival/domain/User.java
+++ b/src/main/java/likelion/festival/domain/User.java
@@ -20,6 +20,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = true)
     private String name;
 
     @Enumerated(EnumType.STRING)
@@ -30,8 +31,8 @@ public class User {
 
     private String refreshToken;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<LostItem> lostItems = new ArrayList<>();
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+//    private List<LostItem> lostItems = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Waiting> waitingList = new ArrayList<>();

--- a/src/main/java/likelion/festival/dto/AdminLoginDto.java
+++ b/src/main/java/likelion/festival/dto/AdminLoginDto.java
@@ -1,0 +1,11 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminLoginDto {
+    private String username;
+    private String password;
+}

--- a/src/main/java/likelion/festival/repository/PubRepository.java
+++ b/src/main/java/likelion/festival/repository/PubRepository.java
@@ -4,7 +4,10 @@ import likelion.festival.domain.Pub;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PubRepository extends JpaRepository<Pub, Long> {
     List<Pub> findAllByOrderByLikeCountDesc();
+
+    Optional<Pub> findByName(String name);
 }

--- a/src/main/java/likelion/festival/service/AuthService.java
+++ b/src/main/java/likelion/festival/service/AuthService.java
@@ -4,14 +4,19 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import likelion.festival.domain.Pub;
 import likelion.festival.domain.User;
 import likelion.festival.dto.KakaoUserInfo;
+import likelion.festival.repository.PubRepository;
 import likelion.festival.repository.UserRepository;
 import likelion.festival.utils.JwtTokenUtils;
 import likelion.festival.utils.KakaoUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.management.RuntimeMBeanException;
 
 @Service
 @Slf4j
@@ -21,21 +26,25 @@ public class AuthService {
     private final UserService userService;
     private final JwtTokenUtils jwtTokenUtils;
     private final Integer maxAge;
+    private final PubRepository pubRepository;
 
     public AuthService(
             KakaoUtils kakaoUtils,
             UserRepository userRepository,
             UserService userService,
             JwtTokenUtils jwtTokenUtils,
-            @Value("${jwt.refresh-token-expire-time}") Integer maxAge
+            @Value("${jwt.refresh-token-expire-time}") Integer maxAge,
+            PubRepository pubRepository
     ) {
         this.kakaoUtils = kakaoUtils;
         this.userRepository = userRepository;
         this.userService = userService;
         this.jwtTokenUtils = jwtTokenUtils;
         this.maxAge = maxAge;
+        this.pubRepository = pubRepository;
     }
 
+    @Transactional
     public void doLoginProcess(String code, HttpServletResponse response) {
         String accessToken = kakaoUtils.getAccessToken(code);
 
@@ -65,5 +74,25 @@ public class AuthService {
         cookie.setMaxAge(maxAge);
 
         response.addCookie(cookie);
+    }
+
+    @Transactional
+    public void adminLogin(String username, String password, HttpServletResponse response) {
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 계정을 요구하고 있습니다."));
+
+        Pub pub = pubRepository.findByName(username)
+                .orElseThrow(() -> new RuntimeException("찾고 있는 주점이 없습니다."));
+
+        if (!pub.getPassword().equals(password)) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String token = jwtTokenUtils.generateAccessToken(user);
+        String refreshToken = jwtTokenUtils.generateRefreshToken(user);
+
+        response.setHeader("Authorization", "Bearer " + token);
+        user.updateRefreshToken(refreshToken);
+        setRefreshToken(refreshToken, response);
     }
 }

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -36,7 +36,7 @@ public class JwtTokenUtils {
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getId()))
+                .setSubject(String.valueOf(user.getEmail()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -49,7 +49,7 @@ public class JwtTokenUtils {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getId()))
+                .setSubject(String.valueOf(user.getEmail()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();


### PR DESCRIPTION
## 📌 관리자 로그인 api 추가

---

## 📝 변경사항
- Pub 엔티티에 password 속성 추가 (관리자 로그인 시, 사용)
- Pub 엔티티에 name 속성 추가(관리자 로그인 시, user의 email 속성과 매칭)
- JWT 생성 시, subject를 id -> email 변경 (오류 발생)

---

## 🔍 테스트 방법
- postman으로 테스트 가능

---

## 💬 기타 참고사항
- 웨이팅 api를 제외한 나머지 api 테스트 완료!