### PR TITLE
클라이언트 에러 예외 처리 로직 추가

### DIFF
--- a/src/main/java/likelion/festival/controller/AdminController.java
+++ b/src/main/java/likelion/festival/controller/AdminController.java
@@ -1,5 +1,6 @@
 package likelion.festival.controller;
 
+import jakarta.validation.Valid;
 import likelion.festival.domain.GuestWaiting;
 import likelion.festival.dto.AdminDeleteDto;
 import likelion.festival.dto.AdminWaitingList;
@@ -37,7 +38,7 @@ public class AdminController {
     }
 
     @PostMapping
-    public GuestWaitingResponseDto addGuestWaiting(@RequestBody GuestWaitingRequestDto guestWaitingRequestDto) {
+    public GuestWaitingResponseDto addGuestWaiting(@Valid @RequestBody GuestWaitingRequestDto guestWaitingRequestDto) {
         GuestWaiting guestWaiting = guestWaitingService.addGuestWaiting(guestWaitingRequestDto);
 
         return new GuestWaitingResponseDto(guestWaiting);

--- a/src/main/java/likelion/festival/dto/AdminWaitingList.java
+++ b/src/main/java/likelion/festival/dto/AdminWaitingList.java
@@ -1,10 +1,12 @@
 package likelion.festival.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
+@Getter
 public class AdminWaitingList {
     private Long id;
     private LocalDateTime createdAt;

--- a/src/main/java/likelion/festival/dto/GuestWaitingRequestDto.java
+++ b/src/main/java/likelion/festival/dto/GuestWaitingRequestDto.java
@@ -1,14 +1,20 @@
 package likelion.festival.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
 public class GuestWaitingRequestDto {
+
+    @NotNull(message = "pubId는 필수 입력 속성입니다.")
     private Long pubId;
 
+    @NotNull(message = "visitorCount는 필수 입력 속성입니다.")
     private Integer visitorCount;
 
+    @NotBlank(message = "phoneNumber는 필수 입력 속성입니다.")
     private String phoneNumber;
 }

--- a/src/main/java/likelion/festival/dto/MyWaitingList.java
+++ b/src/main/java/likelion/festival/dto/MyWaitingList.java
@@ -1,7 +1,9 @@
 package likelion.festival.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public class MyWaitingList {
     private Long waitingId;

--- a/src/main/java/likelion/festival/dto/PubResponseDto.java
+++ b/src/main/java/likelion/festival/dto/PubResponseDto.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 @Getter
 public class PubResponseDto {
     private Long id;
+    private String name;
     private Long likeCount;
 
     public PubResponseDto(Pub pub) {
         this.id = pub.getId();
+        this.name = pub.getName();
         this.likeCount = pub.getLikeCount();
     }
 }

--- a/src/main/java/likelion/festival/exceptions/EntityNotFoundException.java
+++ b/src/main/java/likelion/festival/exceptions/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package likelion.festival.exceptions;
+
+public class EntityNotFoundException extends RuntimeException {
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -62,5 +63,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<String> handleEntityNotFoundError(EntityNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<String> handleRequestParamError(MissingServletRequestParameterException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("필수 query parameter " + ex.getParameterName() + " 가 전달되지 않았습니다.");
     }
 }

--- a/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
@@ -67,6 +67,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<String> handleRequestParamError(MissingServletRequestParameterException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("필수 query parameter " + ex.getParameterName() + " 가 전달되지 않았습니다.");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("필수 쿼리 파라미터 " + ex.getParameterName() + " 가 전달되지 않았습니다.");
     }
 }

--- a/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package likelion.festival.exceptions;
 
+import likelion.festival.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -36,6 +37,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
+    // request body를 json 변환 후, 검증 조건을 만족하지 않음
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException ex) {
         String errorMessage = ex.getBindingResult().getFieldErrors().stream()
@@ -46,8 +48,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(errorMessage);
     }
 
+    // 요청 json을 읽을 수 없음
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<String> handleJsonBindingError(HttpMessageNotReadableException ex) {
-        return ResponseEntity.badRequest().body("잘못된 JSON 형식입니다. 타입이 올바른지 확인하세요.");
+        return ResponseEntity.badRequest().body("잘못된 JSON 형식입니다. 타입이 올바른지 확인하세요." + ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<String> handleRequestError(InvalidRequestException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<String> handleEntityNotFoundError(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 }

--- a/src/main/java/likelion/festival/exceptions/InvalidRequestException.java
+++ b/src/main/java/likelion/festival/exceptions/InvalidRequestException.java
@@ -1,0 +1,7 @@
+package likelion.festival.exceptions;
+
+public class InvalidRequestException extends RuntimeException {
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/exceptions/MissingImageException.java
+++ b/src/main/java/likelion/festival/exceptions/MissingImageException.java
@@ -1,7 +1,0 @@
-package likelion.festival.exceptions;
-
-public class MissingImageException extends RuntimeException {
-    public MissingImageException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -27,6 +28,7 @@ public class AdminService {
         adminWaitingList.addAll(waitingService.getAdminWaitingList(pubId));
         adminWaitingList.addAll(guestWaitingService.getAdminWaitingList(pubId));
 
+        adminWaitingList.sort(Comparator.comparing(AdminWaitingList::getWaitingNum));
         return adminWaitingList;
     }
 

--- a/src/main/java/likelion/festival/service/LostItemService.java
+++ b/src/main/java/likelion/festival/service/LostItemService.java
@@ -5,6 +5,8 @@ import likelion.festival.domain.User;
 import likelion.festival.dto.LostItemDetailResponseDto;
 import likelion.festival.dto.LostItemListResponseDto;
 import likelion.festival.dto.LostItemRequestDto;
+import likelion.festival.exceptions.EntityNotFoundException;
+import likelion.festival.exceptions.InvalidRequestException;
 import likelion.festival.repository.LostItemRepository;
 import likelion.festival.repository.UserRepository;
 import lombok.Getter;
@@ -37,15 +39,12 @@ public class LostItemService {
 
     public LostItemDetailResponseDto findLostItem(Long lostItemId) {
         LostItem lostItem = lostItemRepository.findById(lostItemId)
-                .orElseThrow();
+                .orElseThrow(() -> new EntityNotFoundException("요청한 id를 가진 분실물이 존재하지 않습니다: " + lostItemId));
         return new LostItemDetailResponseDto(lostItem);
     }
 
     @Transactional
     public LostItem addLostItem(LostItemRequestDto dto, MultipartFile image) {
-//        User user = userRepository.findById(dto.getUserId())
-//                .orElse(null);
-
         String imageUrl = imageService.saveImage(image);
 
         LostItem lostItem = new LostItem(

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -2,6 +2,7 @@ package likelion.festival.service;
 
 import likelion.festival.domain.Pub;
 import likelion.festival.dto.PubResponseDto;
+import likelion.festival.exceptions.EntityNotFoundException;
 import likelion.festival.exceptions.PubException;
 import likelion.festival.repository.PubRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class PubService {
 
     @Transactional
     public Pub getPubById(Long id) {
-        return pubRepository.findById(id).orElseThrow(() -> new PubException("No pub with id" + id));
+        return pubRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("No pub with id: " + id));
     }
 
     public List<PubResponseDto> getPubRanks() {
@@ -30,7 +31,7 @@ public class PubService {
     @Transactional
     public void addPubLike(Long pubId, Long addCount) {
         Pub pub = pubRepository.findById(pubId)
-                .orElseThrow();
+                .orElseThrow(() -> new EntityNotFoundException("요청한 id를 가진 주점을 찾을 수 없습니다: " + pubId));
         pub.addLikeCount(addCount);
     }
 }

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -7,6 +7,7 @@ import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.MyWaitingList;
 import likelion.festival.dto.WaitingRequestDto;
 import likelion.festival.dto.WaitingResponseDto;
+import likelion.festival.exceptions.EntityNotFoundException;
 import likelion.festival.exceptions.PubException;
 import likelion.festival.exceptions.WaitingException;
 import likelion.festival.repository.WaitingRepository;
@@ -50,6 +51,9 @@ public class WaitingService {
 
     @Transactional
     public void deleteWaiting(Long waitingId) {
+        if (!waitingRepository.existsById(waitingId)) {
+            throw new EntityNotFoundException("해당 id를 가진 웨이팅이 존재하지 않습니다: " + waitingId);
+        }
         waitingRepository.deleteById(waitingId);
     }
 


### PR DESCRIPTION
## 📌 클라이언트 에러 예외 처리 로직 추가


---

## 📝 변경사항
- EntityNotFoundError, InvalidRequestError 추가로 정의
- 분실 날짜(1일차, 2일차 3일차) 검증 등, 각종 예외처리
- 관리자 웨이팅 조회에서 waitingNum 으로 오름차순 정렬하여 반환

---

## 🔍 테스트 방법
- 추가된 예외처리는 커밋 내역 참고!

---

## 💬 기타 참고사항