### PR TITLE
인증 컨트롤러와 웨이팅 컨트롤러 테스트 코드 추가 및 오류 수정

### DIFF
--- a/src/main/java/likelion/festival/controller/WaitingController.java
+++ b/src/main/java/likelion/festival/controller/WaitingController.java
@@ -32,8 +32,8 @@ public class WaitingController {
     }
 
     @DeleteMapping
-    public String removeWaiting(@RequestParam Long waitingId) {
-        waitingService.deleteWaiting(waitingId);
+    public String removeWaiting(@RequestParam Long id) {
+        waitingService.deleteWaiting(id);
         return "Delete Successfully!";
     }
 

--- a/src/main/java/likelion/festival/domain/Waiting.java
+++ b/src/main/java/likelion/festival/domain/Waiting.java
@@ -2,6 +2,8 @@ package likelion.festival.domain;
 
 import jakarta.persistence.*;
 import likelion.festival.enums.WaitingStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/likelion/festival/dto/MyWaitingList.java
+++ b/src/main/java/likelion/festival/dto/MyWaitingList.java
@@ -1,10 +1,12 @@
 package likelion.festival.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class MyWaitingList {
     private Long waitingId;
     private Integer wholeWaitingNum;

--- a/src/main/java/likelion/festival/repository/PubRepository.java
+++ b/src/main/java/likelion/festival/repository/PubRepository.java
@@ -2,6 +2,7 @@ package likelion.festival.repository;
 
 import likelion.festival.domain.Pub;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +11,12 @@ public interface PubRepository extends JpaRepository<Pub, Long> {
     List<Pub> findAllByOrderByLikeCountDesc();
 
     Optional<Pub> findByName(String name);
+
+    @Query("""
+    SELECT p FROM Pub p
+    LEFT JOIN FETCH p.waitingList w
+    LEFT JOIN FETCH p.guestWaitingList g
+    WHERE p.id = :pubId
+""")
+    Pub findPubWithWaitingsAndGuestWaitings(Long pubId);
 }

--- a/src/main/java/likelion/festival/repository/WaitingRepository.java
+++ b/src/main/java/likelion/festival/repository/WaitingRepository.java
@@ -13,7 +13,7 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     @Query("SELECT new likelion.festival.dto.MyWaitingList(" +
             "w.id, " +
             "p.maxWaitingNum - p.enterNum, " +
-            "p.enterNum - w.waitingNum, " +
+            "w.waitingNum - p.enterNum, " +
             "p.id, " +
             "w.visitorCount) " +
             "FROM Waiting w " +

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -36,7 +36,7 @@ public class JwtTokenUtils {
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getEmail()))
+                .setSubject(String.valueOf(user.getId()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -49,7 +49,7 @@ public class JwtTokenUtils {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getEmail()))
+                .setSubject(String.valueOf(user.getId()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -61,7 +61,7 @@ public class JwtTokenUtils {
         }
 
         for (Cookie cookie : request.getCookies()) {
-            if ("refresh_token".equals(cookie.getName())) {
+            if ("refreshToken".equals(cookie.getName())) {
                 return cookie.getValue();
             }
         }

--- a/src/test/java/likelion/festival/AuthControllerTest.java
+++ b/src/test/java/likelion/festival/AuthControllerTest.java
@@ -1,0 +1,65 @@
+package likelion.festival;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import likelion.festival.domain.Pub;
+import likelion.festival.domain.User;
+import likelion.festival.enums.RoleType;
+import likelion.festival.repository.UserRepository;
+import likelion.festival.utils.JwtTokenUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtTokenUtils jwtTokenUtils;
+
+    private User testUser;
+    private String refreshToken;
+    private Pub testPub;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .name("test")
+                .email("test@test.com")
+                .role(RoleType.ROLE_USER)
+                .build();
+        userRepository.save(testUser);
+
+        refreshToken = jwtTokenUtils.generateRefreshToken(testUser);
+        testUser.updateRefreshToken(refreshToken);
+    }
+
+    @Test
+    void testRefreshTokenApi() throws Exception {
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(new Cookie("refreshToken", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Authorization"))
+                .andExpect(content().string("Token refreshed"));
+    }
+
+    void testAdminLogin() throws Exception {
+
+    }
+}

--- a/src/test/java/likelion/festival/WaitingControllerTest.java
+++ b/src/test/java/likelion/festival/WaitingControllerTest.java
@@ -3,10 +3,12 @@ package likelion.festival;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import likelion.festival.domain.Pub;
 import likelion.festival.domain.User;
+import likelion.festival.domain.Waiting;
 import likelion.festival.dto.WaitingRequestDto;
 import likelion.festival.enums.RoleType;
 import likelion.festival.repository.PubRepository;
 import likelion.festival.repository.UserRepository;
+import likelion.festival.repository.WaitingRepository;
 import likelion.festival.utils.JwtTokenUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -40,10 +42,17 @@ public class WaitingControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private WaitingRepository waitingRepository;
+
     private String token;
     private User testUser;
     private Pub testPub;
     private Long pubId;
+    private Waiting waiting;
+    private Waiting waiting2;
+    private Waiting waiting3;
+    private Long waitingId;
 
     @BeforeEach
     void setUp() {
@@ -80,7 +89,25 @@ public class WaitingControllerTest {
                 .andExpect(jsonPath("$.numsTeamsAhead").value(8));
     }
 
-    void testDeleteWaiting() throws Exception {
-
+    void initWaiting() {
+        waiting = new Waiting(3, "010-1234-5678", "test", 12, testUser, testPub);
+        waitingRepository.save(waiting);
+        waitingId = waiting.getId();
     }
+
+    @Test
+    void testDeleteWaiting() throws Exception {
+        initWaiting();
+        mockMvc.perform(delete("/api/waitings").param("id", String.valueOf(waitingId))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testDeleteWaitingByWrongId() throws Exception {
+        mockMvc.perform(delete("/api/waitings").param("id", String.valueOf(1000999))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().is4xxClientError());
+    }
+
 }

--- a/src/test/java/likelion/festival/WaitingControllerTest.java
+++ b/src/test/java/likelion/festival/WaitingControllerTest.java
@@ -1,4 +1,4 @@
-package likelion.festival.waiting;
+package likelion.festival;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import likelion.festival.domain.Pub;
@@ -55,7 +55,7 @@ public class WaitingControllerTest {
         userRepository.save(testUser);
 
         testPub = Pub.builder()
-                .host("test")
+                .name("test")
                 .enterNum(3)
                 .likeCount(1000L)
                 .maxWaitingNum(10)
@@ -78,5 +78,9 @@ public class WaitingControllerTest {
                 .andExpect(jsonPath("$.id").value(pubId))
                 .andExpect(jsonPath("$.waitingNum").value(11))
                 .andExpect(jsonPath("$.numsTeamsAhead").value(8));
+    }
+
+    void testDeleteWaiting() throws Exception {
+
     }
 }


### PR DESCRIPTION
## 📌 인증 컨트롤러와 웨이팅 컨트롤러 테스트 코드 추가 및 오류 수정


---

## 📝 변경사항
- 웨이팅 컨트롤러에서 유저 웨이팅 리스트 데이터가 현장 웨이팅 리스트도 고려하게 변경했습니다
- 인증 컨트롤러가 테스트 코드 추가해서 잘 동작하는 것 확인했습니다

---

## 🔍 테스트 방법
- 테스트 코드 및 Postman

---

## 💬 기타 참고사항