### PR TITLE
관리자 웨이팅 삭제/입장 처리 오류 수정

### DIFF
--- a/src/main/java/likelion/festival/dto/AdminDeleteDto.java
+++ b/src/main/java/likelion/festival/dto/AdminDeleteDto.java
@@ -8,5 +8,4 @@ import lombok.Getter;
 public class AdminDeleteDto {
     private Long id;
     private String type;
-    private String fcmToken;
 }

--- a/src/main/java/likelion/festival/dto/GuestWaitingResponseDto.java
+++ b/src/main/java/likelion/festival/dto/GuestWaitingResponseDto.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GuestWaitingResponseDto {
+    private Long id;
+
     private Integer visitorCount;
 
     private String phoneNumber;
@@ -14,6 +16,7 @@ public class GuestWaitingResponseDto {
     private Integer waitingNum;
 
     public GuestWaitingResponseDto(GuestWaiting guestWaiting) {
+        this.id = guestWaiting.getId();
         this.visitorCount = guestWaiting.getVisitorCount();
         this.phoneNumber = guestWaiting.getPhoneNumber();
         this.waitingNum = guestWaiting.getWaitingNum();

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -4,9 +4,13 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import likelion.festival.domain.User;
+import likelion.festival.domain.Waiting;
 import likelion.festival.dto.AdminDeleteDto;
 import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.FcmTokenRequest;
+import likelion.festival.exceptions.EntityNotFoundException;
+import likelion.festival.repository.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +26,7 @@ public class AdminService {
     private final WaitingService waitingService;
     private final GuestWaitingService guestWaitingService;
     private final FCMService fcmService;
+    private final WaitingRepository waitingRepository;
 
     public List<AdminWaitingList> getWaitingList(Long pubId) {
         List<AdminWaitingList> adminWaitingList = new ArrayList<>();
@@ -35,11 +40,9 @@ public class AdminService {
     @Transactional
     public void completeWaiting(AdminDeleteDto adminDeleteDto) {
         if (adminDeleteDto.getType().equals("Online")) {
-            waitingService.deleteWaiting(adminDeleteDto.getId());
-            sendCompleteWaitingMessage(adminDeleteDto.getFcmToken());
+            sendCompleteWaitingMessage(deleteWaitingAndReturnFcmToken(adminDeleteDto.getId()));
         } else if (adminDeleteDto.getType().equals("WalkIn")) {
             guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
-            sendCompleteWaitingMessage(adminDeleteDto.getFcmToken());
         } else {
             throw new RuntimeException("Invalid waiting type");
         }
@@ -48,14 +51,20 @@ public class AdminService {
     @Transactional
     public void deleteWaiting(AdminDeleteDto adminDeleteDto) {
         if (adminDeleteDto.getType().equals("Online")) {
-            waitingService.deleteWaiting(adminDeleteDto.getId());
-            sendDeletedWaitingMessage(adminDeleteDto.getFcmToken());
+            sendDeletedWaitingMessage(deleteWaitingAndReturnFcmToken(adminDeleteDto.getId()));
         } else if (adminDeleteDto.getType().equals("WalkIn")) {
             guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
-            sendDeletedWaitingMessage(adminDeleteDto.getFcmToken());
         } else {
             throw new RuntimeException("Invalid waiting type");
         }
+    }
+
+    @Transactional
+    public String deleteWaitingAndReturnFcmToken(Long waitingId) {
+        Waiting waiting = waitingService.getWaiting(waitingId);
+        User user = waiting.getUser();
+        waitingRepository.delete(waiting);
+        return user.getFcmToken();
     }
 
     private void sendCompleteWaitingMessage(String token) {

--- a/src/main/java/likelion/festival/service/GuestWaitingService.java
+++ b/src/main/java/likelion/festival/service/GuestWaitingService.java
@@ -4,6 +4,7 @@ import likelion.festival.domain.GuestWaiting;
 import likelion.festival.domain.Pub;
 import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.GuestWaitingRequestDto;
+import likelion.festival.exceptions.EntityNotFoundException;
 import likelion.festival.repository.GuestWaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,8 @@ public class GuestWaitingService {
 
     @Transactional
     public void deleteGuestWaiting(Long guestWaitingId) {
-        guestWaitingRepository.deleteById(guestWaitingId);
+        GuestWaiting guestWaiting = guestWaitingRepository.findById(guestWaitingId)
+                .orElseThrow(() -> new EntityNotFoundException("WalkIn Waiting is not found given id " + guestWaitingId));
+        guestWaitingRepository.delete(guestWaiting);
     }
 }

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -59,14 +59,18 @@ public class WaitingService {
                 pub));
     }
 
+    public Waiting getWaiting(Long waitingId) {
+        return waitingRepository.findById(waitingId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 id를 가진 웨이팅이 존재하지 않습니다: " + waitingId));
+    }
+
     @Transactional
     public void deleteWaiting(Long waitingId) {
 //        if (!waitingRepository.existsById(waitingId)) {
 //            throw new EntityNotFoundException("해당 id를 가진 웨이팅이 존재하지 않습니다: " + waitingId);
 //        }
 //        waitingRepository.deleteById(waitingId);
-        Waiting waiting = waitingRepository.findById(waitingId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 id를 가진 웨이팅이 존재하지 않습니다: " + waitingId));
+        Waiting waiting = getWaiting(waitingId);
         waitingRepository.delete(waiting);
     }
 

--- a/src/test/java/likelion/festival/AdminControllerTest.java
+++ b/src/test/java/likelion/festival/AdminControllerTest.java
@@ -1,0 +1,11 @@
+package likelion.festival;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AdminControllerTest {
+}


### PR DESCRIPTION
## 📌관리자 웨이팅 삭제/입장 처리 오류 수정


---

## 📝 변경사항
1. 현장 웨이팅 입장 완료/ 삭제 시 fcm 알림 보내는 로직 삭제
2. 요청 바디에서 fcm 토큰을 받는 로직 삭제
3. 웨이팅 id로 보내면 그 웨이팅을 걸은 유저의 fcm 토큰을 조회해서 그 토큰으로 메시지를 보내도록 수정

---

## 🔍 테스트 방법
- Postman
---

## 💬 기타 참고사항