### PR TITLE
분실물 조회, 주점 조회, 주점 좋아요 api 인증 제거, jwt 401 에러 정의

### DIFF
--- a/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
+++ b/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import likelion.festival.exceptions.JwtTokenException;
 import likelion.festival.utils.JwtTokenUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         for (String string : WHITELIST) {
             if (path.startsWith(string)) {
+                if (path.equals("/api/lost-items") && request.getMethod().equals("POST")) {
+                    break;
+                }
+
                 filterChain.doFilter(request, response);
                 return;
             }
@@ -63,7 +68,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         log.info(request.getRequestURI());
         log.info(request.getMethod());
-        throw new RuntimeException("token is invalid or null");
+        throw new JwtTokenException("token is invalid or null");
     }
 }
 

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -22,6 +22,8 @@ public class SecurityConfig {
             "/admin/waiting",
             "/auth/refresh",
             "/auth/admin-login",
+            "/api/lost-items",
+            "/api/pubs",
             "/images"
     };
 
@@ -31,7 +33,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/images/**").permitAll()
+                        .requestMatchers("/images/**", "/api/lost-items/**", "/api/pubs/**").permitAll()
                         .requestMatchers(WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
             new WhitelistEntry(HttpMethod.GET, "/api/lost-items/**"),
             new WhitelistEntry(HttpMethod.GET, "/api/pubs"),
             new WhitelistEntry(HttpMethod.POST, "/api/pubs/like"),
-            new WhitelistEntry(HttpMethod.POST, "/images/**")
+            new WhitelistEntry(HttpMethod.GET, "/images/**")
     );
 
     @Bean

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -28,10 +28,10 @@ public class SecurityConfig {
             new WhitelistEntry(HttpMethod.DELETE, "/admin/waiting"),
             new WhitelistEntry(HttpMethod.POST, "/auth/refresh"),
             new WhitelistEntry(HttpMethod.POST, "/auth/admin-login"),
-            new WhitelistEntry(HttpMethod.GET, "/api/lost-items/*"),
+            new WhitelistEntry(HttpMethod.GET, "/api/lost-items/**"),
             new WhitelistEntry(HttpMethod.GET, "/api/pubs"),
             new WhitelistEntry(HttpMethod.POST, "/api/pubs/like"),
-            new WhitelistEntry(HttpMethod.POST, "/images/*")
+            new WhitelistEntry(HttpMethod.POST, "/images/**")
     );
 
     @Bean

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package likelion.festival.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -33,7 +34,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/images/**", "/api/lost-items/**", "/api/pubs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/lost-items/**").permitAll()
+                        .requestMatchers("/images/**", "/api/pubs/**").permitAll()
                         .requestMatchers(WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/likelion/festival/config/WhitelistEntry.java
+++ b/src/main/java/likelion/festival/config/WhitelistEntry.java
@@ -1,0 +1,12 @@
+package likelion.festival.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpMethod;
+
+@Getter
+@AllArgsConstructor
+public class WhitelistEntry {
+    private HttpMethod method;
+    private String path;
+}

--- a/src/main/java/likelion/festival/exceptions/JwtAuthenticationException.java
+++ b/src/main/java/likelion/festival/exceptions/JwtAuthenticationException.java
@@ -1,0 +1,10 @@
+package likelion.festival.exceptions;
+
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/service/AuthService.java
+++ b/src/main/java/likelion/festival/service/AuthService.java
@@ -7,6 +7,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import likelion.festival.domain.Pub;
 import likelion.festival.domain.User;
 import likelion.festival.dto.KakaoUserInfo;
+import likelion.festival.exceptions.InvalidRequestException;
+import likelion.festival.exceptions.PubException;
+import likelion.festival.exceptions.UserNotFoundException;
 import likelion.festival.repository.PubRepository;
 import likelion.festival.repository.UserRepository;
 import likelion.festival.utils.JwtTokenUtils;
@@ -79,13 +82,13 @@ public class AuthService {
     @Transactional
     public void adminLogin(String username, String password, HttpServletResponse response) {
         User user = userRepository.findByEmail(username)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 계정을 요구하고 있습니다."));
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 계정을 요구하고 있습니다."));
 
         Pub pub = pubRepository.findByName(username)
-                .orElseThrow(() -> new RuntimeException("찾고 있는 주점이 없습니다."));
+                .orElseThrow(() -> new PubException("찾고 있는 주점이 없습니다."));
 
         if (!pub.getPassword().equals(password)) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+            throw new InvalidRequestException("비밀번호가 일치하지 않습니다.");
         }
 
         String token = jwtTokenUtils.generateAccessToken(user);

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import likelion.festival.domain.User;
+import likelion.festival.exceptions.JwtAuthenticationException;
 import likelion.festival.exceptions.JwtTokenException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -76,14 +77,8 @@ public class JwtTokenUtils {
                     .build()
                     .parseClaimsJws(token);
             return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            throw new JwtTokenException("Invalid JWT token");
-        } catch (ExpiredJwtException e) {
-            throw new JwtTokenException("Expired");
-        } catch (UnsupportedJwtException e) {
-            throw new JwtTokenException("Unsupported JWT token");
-        } catch (IllegalArgumentException e) {
-            throw new JwtTokenException("Invalid JWT token");
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new JwtAuthenticationException("유효하지 않은 JWT 토큰입니다.: " + e.getMessage());
         }
     }
 

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -22,7 +22,7 @@ public class JwtTokenUtils {
 
     private final Key key;
 
-    private long expirationTime;
+    private final long expirationTime;
 
     public JwtTokenUtils(@Value("${jwt.secret-key}") String secretKey, @Value("${jwt.expire-time}") long expirationTime) {
         this.expirationTime = expirationTime;
@@ -37,7 +37,7 @@ public class JwtTokenUtils {
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getEmail()))
+                .setSubject(String.valueOf(user.getId()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -50,7 +50,7 @@ public class JwtTokenUtils {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getEmail()))
+                .setSubject(String.valueOf(user.getId()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -77,8 +77,12 @@ public class JwtTokenUtils {
                     .build()
                     .parseClaimsJws(token);
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new JwtAuthenticationException("유효하지 않은 JWT 토큰입니다.: " + e.getMessage());
+        } catch (SecurityException | MalformedJwtException | IllegalArgumentException e) {
+            throw new JwtAuthenticationException("Invalid JWT token");
+        } catch (ExpiredJwtException e) {
+            throw new JwtAuthenticationException("Expired");
+        } catch (UnsupportedJwtException e) {
+            throw new JwtAuthenticationException("Unsupported JWT token");
         }
     }
 


### PR DESCRIPTION
## 📌 분실물 조회, 주점 조회, 주점 좋아요 api 인증 제거, jwt 401 에러 정의


---

## 📝 변경사항
- admin login에서 발생하는 에러 RuntimeException -> 커스텀 400 에러로 변경
- 분실물 조회, 주점 조회와 좋아요 api 인증 요구 제거
- jwt 인증 과정에서 발생하는 500 에러에 에러 내용을 알 수 없는 상황 
    -> JwtAuthenticationError 정의, 401에러가 뜨도록 설정 
- JwtUtils에 있는 validate 메소드 에러 발생 부분 정리

---

## 🔍 테스트 방법

---

## 💬 기타 참고사항