### PR TITLE
좋아요 증가 api 수정

### DIFF
--- a/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
+++ b/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import likelion.festival.exceptions.JwtTokenException;
 import likelion.festival.utils.JwtTokenUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         for (String string : WHITELIST) {
             if (path.startsWith(string)) {
+                if (path.equals("/api/lost-items") && request.getMethod().equals("POST")) {
+                    break;
+                }
+
                 filterChain.doFilter(request, response);
                 return;
             }
@@ -63,7 +68,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         log.info(request.getRequestURI());
         log.info(request.getMethod());
-        throw new RuntimeException("token is invalid or null");
+        throw new JwtTokenException("token is invalid or null");
     }
 }
 

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -22,6 +22,8 @@ public class SecurityConfig {
             "/admin/waiting",
             "/auth/refresh",
             "/auth/admin-login",
+            "/api/lost-items",
+            "/api/pubs",
             "/images"
     };
 
@@ -31,7 +33,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/images/**").permitAll()
+                        .requestMatchers("/images/**", "/api/lost-items/**", "/api/pubs/**").permitAll()
                         .requestMatchers(WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -28,10 +28,10 @@ public class SecurityConfig {
             new WhitelistEntry(HttpMethod.DELETE, "/admin/waiting"),
             new WhitelistEntry(HttpMethod.POST, "/auth/refresh"),
             new WhitelistEntry(HttpMethod.POST, "/auth/admin-login"),
-            new WhitelistEntry(HttpMethod.GET, "/api/lost-items/*"),
+            new WhitelistEntry(HttpMethod.GET, "/api/lost-items/**"),
             new WhitelistEntry(HttpMethod.GET, "/api/pubs"),
             new WhitelistEntry(HttpMethod.POST, "/api/pubs/like"),
-            new WhitelistEntry(HttpMethod.POST, "/images/*")
+            new WhitelistEntry(HttpMethod.POST, "/images/**")
     );
 
     @Bean

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package likelion.festival.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -33,7 +34,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/images/**", "/api/lost-items/**", "/api/pubs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/lost-items/**").permitAll()
+                        .requestMatchers("/images/**", "/api/pubs/**").permitAll()
                         .requestMatchers(WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/likelion/festival/config/WhitelistEntry.java
+++ b/src/main/java/likelion/festival/config/WhitelistEntry.java
@@ -1,0 +1,12 @@
+package likelion.festival.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpMethod;
+
+@Getter
+@AllArgsConstructor
+public class WhitelistEntry {
+    private HttpMethod method;
+    private String path;
+}

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -22,11 +22,12 @@ public class PubController {
         return ResponseEntity.ok(pubs);
     }
 
-    @PostMapping("{pubId}/likes")
-    public synchronized String addLike(@PathVariable Long pubId, @RequestBody List<PubRequestDto> dtoList) {
+    @PostMapping("/like")
+    public synchronized ResponseEntity<List<PubResponseDto>> addLike(@PathVariable Long pubId, @RequestBody List<PubRequestDto> dtoList) {
         for (PubRequestDto dto : dtoList) {
             pubService.addPubLike(dto.getPubId(), dto.getAddCount());
         }
-        return "좋아요가 성공적으로 반영되었습니다";
+        List<PubResponseDto> pubs = pubService.getPubRanks();
+        return ResponseEntity.ok(pubs);
     }
 }

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -23,8 +23,10 @@ public class PubController {
     }
 
     @PostMapping("{pubId}/likes")
-    public synchronized String addLike(@PathVariable Long pubId, @RequestBody PubRequestDto dto) {
-        pubService.addPubLike(pubId, dto.getAddCount());
+    public synchronized String addLike(@PathVariable Long pubId, @RequestBody List<PubRequestDto> dtoList) {
+        for (PubRequestDto dto : dtoList) {
+            pubService.addPubLike(dto.getPubId(), dto.getAddCount());
+        }
         return "좋아요가 성공적으로 반영되었습니다";
     }
 }

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -23,7 +23,7 @@ public class PubController {
     }
 
     @PostMapping("/like")
-    public synchronized ResponseEntity<List<PubResponseDto>> addLike(@PathVariable Long pubId, @RequestBody List<PubRequestDto> dtoList) {
+    public synchronized ResponseEntity<List<PubResponseDto>> addLike(@RequestBody List<PubRequestDto> dtoList) {
         for (PubRequestDto dto : dtoList) {
             pubService.addPubLike(dto.getPubId(), dto.getAddCount());
         }

--- a/src/main/java/likelion/festival/domain/Pub.java
+++ b/src/main/java/likelion/festival/domain/Pub.java
@@ -42,7 +42,7 @@ public class Pub {
         return this.maxWaitingNum;
     }
 
-    public void addLikeCount(Long addCount) {
+    public void addLikeCount(Integer addCount) {
         this.likeCount += addCount;
     }
 }

--- a/src/main/java/likelion/festival/dto/PubRequestDto.java
+++ b/src/main/java/likelion/festival/dto/PubRequestDto.java
@@ -9,7 +9,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PubRequestDto {
 
+    @NotNull(message = "pubId는 필수 필드입니다.")
+    private Long pubId;
+
     @NotNull(message = "addCount는 필수 필드입니다.")
     @Positive(message = "addCount는 반드시 양수로 입력해야합니다.")
-    private Long addCount;
+    private Integer addCount;
 }

--- a/src/main/java/likelion/festival/exceptions/JwtAuthenticationException.java
+++ b/src/main/java/likelion/festival/exceptions/JwtAuthenticationException.java
@@ -1,0 +1,10 @@
+package likelion.festival.exceptions;
+
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/service/AuthService.java
+++ b/src/main/java/likelion/festival/service/AuthService.java
@@ -7,6 +7,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import likelion.festival.domain.Pub;
 import likelion.festival.domain.User;
 import likelion.festival.dto.KakaoUserInfo;
+import likelion.festival.exceptions.InvalidRequestException;
+import likelion.festival.exceptions.PubException;
+import likelion.festival.exceptions.UserNotFoundException;
 import likelion.festival.repository.PubRepository;
 import likelion.festival.repository.UserRepository;
 import likelion.festival.utils.JwtTokenUtils;
@@ -79,13 +82,13 @@ public class AuthService {
     @Transactional
     public void adminLogin(String username, String password, HttpServletResponse response) {
         User user = userRepository.findByEmail(username)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 계정을 요구하고 있습니다."));
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 계정을 요구하고 있습니다."));
 
         Pub pub = pubRepository.findByName(username)
-                .orElseThrow(() -> new RuntimeException("찾고 있는 주점이 없습니다."));
+                .orElseThrow(() -> new PubException("찾고 있는 주점이 없습니다."));
 
         if (!pub.getPassword().equals(password)) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+            throw new InvalidRequestException("비밀번호가 일치하지 않습니다.");
         }
 
         String token = jwtTokenUtils.generateAccessToken(user);

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -29,7 +29,7 @@ public class PubService {
     }
 
     @Transactional
-    public void addPubLike(Long pubId, Long addCount) {
+    public void addPubLike(Long pubId, Integer addCount) {
         Pub pub = pubRepository.findById(pubId)
                 .orElseThrow(() -> new EntityNotFoundException("요청한 id를 가진 주점을 찾을 수 없습니다: " + pubId));
         pub.addLikeCount(addCount);

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import likelion.festival.domain.User;
+import likelion.festival.exceptions.JwtAuthenticationException;
 import likelion.festival.exceptions.JwtTokenException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -76,14 +77,8 @@ public class JwtTokenUtils {
                     .build()
                     .parseClaimsJws(token);
             return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            throw new JwtTokenException("Invalid JWT token");
-        } catch (ExpiredJwtException e) {
-            throw new JwtTokenException("Expired");
-        } catch (UnsupportedJwtException e) {
-            throw new JwtTokenException("Unsupported JWT token");
-        } catch (IllegalArgumentException e) {
-            throw new JwtTokenException("Invalid JWT token");
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new JwtAuthenticationException("유효하지 않은 JWT 토큰입니다.: " + e.getMessage());
         }
     }
 

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -22,7 +22,7 @@ public class JwtTokenUtils {
 
     private final Key key;
 
-    private long expirationTime;
+    private final long expirationTime;
 
     public JwtTokenUtils(@Value("${jwt.secret-key}") String secretKey, @Value("${jwt.expire-time}") long expirationTime) {
         this.expirationTime = expirationTime;
@@ -37,7 +37,7 @@ public class JwtTokenUtils {
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getEmail()))
+                .setSubject(String.valueOf(user.getId()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -50,7 +50,7 @@ public class JwtTokenUtils {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setIssuedAt(now)
-                .setSubject(String.valueOf(user.getEmail()))
+                .setSubject(String.valueOf(user.getId()))
                 .setExpiration(expiration)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/java/likelion/festival/utils/JwtTokenUtils.java
+++ b/src/main/java/likelion/festival/utils/JwtTokenUtils.java
@@ -77,8 +77,12 @@ public class JwtTokenUtils {
                     .build()
                     .parseClaimsJws(token);
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new JwtAuthenticationException("유효하지 않은 JWT 토큰입니다.: " + e.getMessage());
+        } catch (SecurityException | MalformedJwtException | IllegalArgumentException e) {
+            throw new JwtAuthenticationException("Invalid JWT token");
+        } catch (ExpiredJwtException e) {
+            throw new JwtAuthenticationException("Expired");
+        } catch (UnsupportedJwtException e) {
+            throw new JwtAuthenticationException("Unsupported JWT token");
         }
     }
 


### PR DESCRIPTION
## 📌 주점 좋아요 증가 api 수정


---

## 📝 변경사항
- 한 번의 요청에 모든 주점들에 더해질 좋아요 수를 전달받도록 수정
- 응답으로 갱신된 주점들의 좋아요 수와 랭킹을 반환

---

## 🔍 테스트 방법
- postman

---

## 💬 기타 참고사항
![image](https://github.com/user-attachments/assets/eeb22e06-43c5-471c-9e49-d1fd2e25b8dc)
