### PR TITLE
pubid 직접 전달 -> 인증 토큰에서 로그인된 주점 계정 확인

### DIFF
--- a/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
+++ b/src/main/java/likelion/festival/config/JwtAuthenticationFilter.java
@@ -60,6 +60,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             response.setContentType("application/json; charset=UTF-8");
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.getWriter().write(ex.getMessage());
+            return; // 없으면 인증되지 않아도 controller 과정으로 넘어가게 됨
         }
     }
 

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -23,7 +23,6 @@ public class SecurityConfig {
     public static final List<WhitelistEntry> WHITELIST = List.of(
             new WhitelistEntry(HttpMethod.GET, "/auth/login/kakao/auth-code"),
             new WhitelistEntry(HttpMethod.GET, "/error"),
-            new WhitelistEntry(HttpMethod.DELETE, "/admin/waiting"),
             new WhitelistEntry(HttpMethod.POST, "/auth/refresh"),
             new WhitelistEntry(HttpMethod.POST, "/auth/admin-login"),
             new WhitelistEntry(HttpMethod.GET, "/api/lost-items/**"),

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -23,7 +23,6 @@ public class SecurityConfig {
     public static final List<WhitelistEntry> WHITELIST = List.of(
             new WhitelistEntry(HttpMethod.GET, "/auth/login/kakao/auth-code"),
             new WhitelistEntry(HttpMethod.GET, "/error"),
-            new WhitelistEntry(HttpMethod.GET, "/admin/waiting"),
             new WhitelistEntry(HttpMethod.DELETE, "/admin/waiting"),
             new WhitelistEntry(HttpMethod.POST, "/auth/refresh"),
             new WhitelistEntry(HttpMethod.POST, "/auth/admin-login"),

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -24,7 +24,6 @@ public class SecurityConfig {
             new WhitelistEntry(HttpMethod.GET, "/auth/login/kakao/auth-code"),
             new WhitelistEntry(HttpMethod.GET, "/error"),
             new WhitelistEntry(HttpMethod.GET, "/admin/waiting"),
-            new WhitelistEntry(HttpMethod.POST, "/admin/waiting"),
             new WhitelistEntry(HttpMethod.DELETE, "/admin/waiting"),
             new WhitelistEntry(HttpMethod.POST, "/auth/refresh"),
             new WhitelistEntry(HttpMethod.POST, "/auth/admin-login"),

--- a/src/main/java/likelion/festival/controller/AdminController.java
+++ b/src/main/java/likelion/festival/controller/AdminController.java
@@ -33,8 +33,8 @@ public class AdminController {
     }
 
     @GetMapping
-    public List<AdminWaitingList> getWaitingList(@RequestParam Long pubId) {
-        return adminService.getWaitingList(pubId);
+    public List<AdminWaitingList> getWaitingList() {
+        return adminService.getWaitingList();
     }
 
     @PostMapping

--- a/src/main/java/likelion/festival/dto/GuestWaitingRequestDto.java
+++ b/src/main/java/likelion/festival/dto/GuestWaitingRequestDto.java
@@ -9,9 +9,6 @@ import lombok.Getter;
 @Getter
 public class GuestWaitingRequestDto {
 
-    @NotNull(message = "pubId는 필수 입력 속성입니다.")
-    private Long pubId;
-
     @NotNull(message = "visitorCount는 필수 입력 속성입니다.")
     private Integer visitorCount;
 

--- a/src/main/java/likelion/festival/exceptions/AdminPermissionException.java
+++ b/src/main/java/likelion/festival/exceptions/AdminPermissionException.java
@@ -1,0 +1,7 @@
+package likelion.festival.exceptions;
+
+public class AdminPermissionException extends RuntimeException {
+    public AdminPermissionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package likelion.festival.exceptions;
 
-import likelion.festival.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -8,8 +7,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.lang.reflect.Method;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -68,5 +65,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<String> handleRequestParamError(MissingServletRequestParameterException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("필수 쿼리 파라미터 " + ex.getParameterName() + " 가 전달되지 않았습니다.");
+    }
+
+    @ExceptionHandler(AdminPermissionException.class)
+    public ResponseEntity<String> handleAdminPermission(AdminPermissionException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
     }
 }

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -62,7 +62,7 @@ public class AdminService {
         } else if (adminDeleteDto.getType().equals("WalkIn")) {
             guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
         } else {
-            throw new RuntimeException("Invalid waiting type");
+            throw new InvalidRequestException("type 을 잘 못 전달했습니다. Online, WalkIn 중에 하나로 입력해주세요.");
         }
     }
 

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -4,14 +4,19 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import likelion.festival.config.CustomUserDetails;
+import likelion.festival.domain.Pub;
 import likelion.festival.domain.User;
 import likelion.festival.domain.Waiting;
 import likelion.festival.dto.AdminDeleteDto;
 import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.FcmTokenRequest;
+import likelion.festival.exceptions.AdminPermissionException;
 import likelion.festival.exceptions.EntityNotFoundException;
 import likelion.festival.repository.WaitingRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,11 +32,23 @@ public class AdminService {
     private final GuestWaitingService guestWaitingService;
     private final FCMService fcmService;
     private final WaitingRepository waitingRepository;
+    private final PubService pubService;
 
-    public List<AdminWaitingList> getWaitingList(Long pubId) {
+    public List<AdminWaitingList> getWaitingList() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        boolean isAdmin = userDetails.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            throw new AdminPermissionException("관리자 권한이 없습니다. 관리자 계정으로 로그인해주세요.");
+        }
+        String name = userDetails.getUsername();
+        Pub pub = pubService.getPubByName(name);
+
         List<AdminWaitingList> adminWaitingList = new ArrayList<>();
-        adminWaitingList.addAll(waitingService.getAdminWaitingList(pubId));
-        adminWaitingList.addAll(guestWaitingService.getAdminWaitingList(pubId));
+        adminWaitingList.addAll(waitingService.getAdminWaitingList(pub.getId()));
+        adminWaitingList.addAll(guestWaitingService.getAdminWaitingList(pub.getId()));
 
         adminWaitingList.sort(Comparator.comparing(AdminWaitingList::getWaitingNum));
         return adminWaitingList;

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -13,6 +13,7 @@ import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.FcmTokenRequest;
 import likelion.festival.exceptions.AdminPermissionException;
 import likelion.festival.exceptions.EntityNotFoundException;
+import likelion.festival.exceptions.InvalidRequestException;
 import likelion.festival.repository.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -72,7 +73,7 @@ public class AdminService {
         } else if (adminDeleteDto.getType().equals("WalkIn")) {
             guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
         } else {
-            throw new RuntimeException("Invalid waiting type");
+            throw new InvalidRequestException("type 을 잘 못 전달했습니다. Online, WalkIn 중에 하나로 입력해주세요.");
         }
     }
 

--- a/src/main/java/likelion/festival/service/GuestWaitingService.java
+++ b/src/main/java/likelion/festival/service/GuestWaitingService.java
@@ -1,12 +1,16 @@
 package likelion.festival.service;
 
+import likelion.festival.config.CustomUserDetails;
 import likelion.festival.domain.GuestWaiting;
 import likelion.festival.domain.Pub;
 import likelion.festival.dto.AdminWaitingList;
 import likelion.festival.dto.GuestWaitingRequestDto;
+import likelion.festival.exceptions.AdminPermissionException;
 import likelion.festival.exceptions.EntityNotFoundException;
 import likelion.festival.repository.GuestWaitingRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +25,18 @@ public class GuestWaitingService {
 
     @Transactional
     public GuestWaiting addGuestWaiting(GuestWaitingRequestDto guestWaitingRequestDto) {
-        Pub pub = pubService.getPubById(guestWaitingRequestDto.getPubId());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        boolean isAdmin = userDetails.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            throw new AdminPermissionException("관리자 계정만 현장 예약을 추가할 수 있습니다.");
+        }
+
+        String name = userDetails.getUsername();
+
+        Pub pub = pubService.getPubByName(name);
 
         return guestWaitingRepository.save(
                 new GuestWaiting(guestWaitingRequestDto.getVisitorCount(),

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -22,6 +22,11 @@ public class PubService {
         return pubRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("No pub with id: " + id));
     }
 
+    public Pub getPubByName(String name) {
+        return pubRepository.findByName(name)
+                .orElseThrow(() -> new EntityNotFoundException("해당 이름을 가진 주점이 존재하지 않습니다.: " + name));
+    }
+
     public List<PubResponseDto> getPubRanks() {
         List<Pub> pubs = pubRepository.findAllByOrderByLikeCountDesc();
         return pubs.stream().map(pub -> new PubResponseDto(pub))


### PR DESCRIPTION
## 📌 PR 제목
pubid 직접 전달 -> 인증 토큰에서 로그인된 주점 계정 확인

---

## 📝 변경사항
- RequestBody, RequestParam 등에서 전달받았던  pubId 제거
- jwt 토큰에서 username 추출 후, 로그인된 관리자 계정이 어느 주점인지 확인

- whitelist에서 일부 경로가 삭제되었습니다.
- 관리자 계정이 아닌 일반 계정의 요청일 경우, 예외가 발생하도록 했습니다.

---

## 🔍 테스트 방법
- 예: Postman으로 /login 엔드포인트에 POST 요청 보내기

---

## 💬 기타 참고사항
- 추가 설명이 필요하다면 여기에 적어주세요.