### PR TITLE
waiting 삭제 시, 주점의 enterNum 증가되도록 수정

### DIFF
--- a/src/main/java/likelion/festival/repository/PubRepository.java
+++ b/src/main/java/likelion/festival/repository/PubRepository.java
@@ -2,7 +2,9 @@ package likelion.festival.repository;
 
 import likelion.festival.domain.Pub;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +21,8 @@ public interface PubRepository extends JpaRepository<Pub, Long> {
     WHERE p.id = :pubId
 """)
     Pub findPubWithWaitingsAndGuestWaitings(Long pubId);
+
+    @Modifying
+    @Query("UPDATE Pub p SET p.enterNum = :waitingNum WHERE p.id = :pubId")
+    void incrementEnterNum(@Param("waitingNum") int waitingNum, @Param("pubId") Long pubId);
 }

--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -71,8 +71,11 @@ public class AdminService {
     @Transactional
     public String deleteWaitingAndReturnFcmToken(Long waitingId) {
         Waiting waiting = waitingService.getWaiting(waitingId);
-        User user = waiting.getUser();
+
+        pubService.updateEnterNum(waiting.getWaitingNum(), waiting.getPub().getId());
+
         waitingRepository.delete(waiting);
+        User user = waiting.getUser();
         return user.getFcmToken();
     }
 

--- a/src/main/java/likelion/festival/service/GuestWaitingService.java
+++ b/src/main/java/likelion/festival/service/GuestWaitingService.java
@@ -44,6 +44,7 @@ public class GuestWaitingService {
     public void deleteGuestWaiting(Long guestWaitingId) {
         GuestWaiting guestWaiting = guestWaitingRepository.findById(guestWaitingId)
                 .orElseThrow(() -> new EntityNotFoundException("WalkIn Waiting is not found given id " + guestWaitingId));
+        pubService.updateEnterNum(guestWaiting.getWaitingNum(), guestWaiting.getPub().getId());
         guestWaitingRepository.delete(guestWaiting);
     }
 }

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -39,4 +39,9 @@ public class PubService {
                 .orElseThrow(() -> new EntityNotFoundException("요청한 id를 가진 주점을 찾을 수 없습니다: " + pubId));
         pub.addLikeCount(addCount);
     }
+
+    @Transactional
+    public void updateEnterNum(Integer waitingNum, Long pubId) {
+        pubRepository.incrementEnterNum(waitingNum, pubId);
+    }
 }


### PR DESCRIPTION
## 📌 waiting 삭제 시, 주점의 enterNum 증가되도록 수정


---

## 📝 변경사항
- pubRepository에 쿼리문 직접 작성
- pubService에 enterNum 업데이트 메소드 작성
- 현장 웨이팅, 온라인 웨이팅 삭제 시, 적용되도록 코드 추가

---

## 🔍 테스트 방법
- 예: Postman으로 /login 엔드포인트에 POST 요청 보내기

---

## 💬 기타 참고사항
- 추가 설명이 필요하다면 여기에 적어주세요.