### PR TITLE
fcm 토큰 없이 웨이팅 삭제 가능하게 변경

### DIFF
--- a/src/main/java/likelion/festival/service/AdminService.java
+++ b/src/main/java/likelion/festival/service/AdminService.java
@@ -50,7 +50,10 @@ public class AdminService {
     @Transactional
     public void completeWaiting(AdminDeleteDto adminDeleteDto) {
         if (adminDeleteDto.getType().equals("Online")) {
-            sendCompleteWaitingMessage(deleteWaitingAndReturnFcmToken(adminDeleteDto.getId()));
+            String fcmToken = deleteWaitingAndReturnFcmToken(adminDeleteDto.getId());
+            if (fcmToken != null) {
+                sendCompleteWaitingMessage(fcmToken);
+            }
         } else if (adminDeleteDto.getType().equals("WalkIn")) {
             guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
         } else {
@@ -61,7 +64,10 @@ public class AdminService {
     @Transactional
     public void deleteWaiting(AdminDeleteDto adminDeleteDto) {
         if (adminDeleteDto.getType().equals("Online")) {
-            sendDeletedWaitingMessage(deleteWaitingAndReturnFcmToken(adminDeleteDto.getId()));
+            String fcmToken = deleteWaitingAndReturnFcmToken(adminDeleteDto.getId());
+            if (fcmToken != null) {
+                sendDeletedWaitingMessage(fcmToken);
+            }
         } else if (adminDeleteDto.getType().equals("WalkIn")) {
             guestWaitingService.deleteGuestWaiting(adminDeleteDto.getId());
         } else {


### PR DESCRIPTION
## 📌 fcm 토큰 없이 웨이팅 삭제 가능하게 변경


---

## 📝 변경사항
- fcm 토큰 없다면 메시지 보내지 않게 변경

---

## 🔍 테스트 방법

---

## 💬 기타 참고사항