### PR TITLE
분실물 이미지 업로드 key 변경

### DIFF
--- a/src/main/java/likelion/festival/service/NcpObjectStorageService.java
+++ b/src/main/java/likelion/festival/service/NcpObjectStorageService.java
@@ -21,8 +21,16 @@ public class NcpObjectStorageService {
     private final NcpStorageProperties properties;
 
     public String uploadImage(MultipartFile file) throws IOException {
+        String originalFilename = file.getOriginalFilename();
         String datePath = LocalDate.now().toString();
-        String key = "lost-items/" + datePath + "/" + UUID.randomUUID() + "-" + file.getOriginalFilename();
+        String fileExtension;
+
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            fileExtension = "";
+        } else {
+            fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".")+1);
+        }
+        String key = "lost-items/" + datePath + "/" + UUID.randomUUID() + "." + fileExtension;
 
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(properties.getBucket())


### PR DESCRIPTION
## 📌 분실물 이미지 업로드 key 변경


---

## 📝 변경사항
- 업로드하는 파일 이름을 변경(uuid + 파일이름 + 확장자 -> uuid + 확장자)

---

## 🔍 테스트 방법
- 예: Postman으로 /login 엔드포인트에 POST 요청 보내기

---

## 💬 기타 참고사항
- 추가 설명이 필요하다면 여기에 적어주세요.