### PR TITLE
주점의 전체 웨이팅 수만 조회하는 api 추가

### DIFF
--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -1,7 +1,9 @@
 package likelion.festival.controller;
 
+import likelion.festival.domain.Pub;
 import likelion.festival.dto.PubRequestDto;
 import likelion.festival.dto.PubResponseDto;
+import likelion.festival.dto.PubTotalWaitingResponse;
 import likelion.festival.service.PubService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,5 +31,12 @@ public class PubController {
         }
         List<PubResponseDto> pubs = pubService.getPubRanks();
         return ResponseEntity.ok(pubs);
+    }
+
+    @GetMapping("/{pubId}/waiting-count")
+    public ResponseEntity<PubTotalWaitingResponse> getPubTotalWaitingCount(@PathVariable Long pubId) {
+        Integer totalCount = pubService.getTotalWaiting(pubId);
+        PubTotalWaitingResponse response = new PubTotalWaitingResponse(totalCount);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/likelion/festival/dto/PubTotalWaitingResponse.java
+++ b/src/main/java/likelion/festival/dto/PubTotalWaitingResponse.java
@@ -1,0 +1,10 @@
+package likelion.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PubTotalWaitingResponse {
+    private Integer waitingCount;
+}

--- a/src/main/java/likelion/festival/repository/PubRepository.java
+++ b/src/main/java/likelion/festival/repository/PubRepository.java
@@ -22,7 +22,7 @@ public interface PubRepository extends JpaRepository<Pub, Long> {
     LEFT JOIN FETCH p.guestWaitingList g
     WHERE p.id = :pubId
 """)
-    Pub findPubWithWaitingsAndGuestWaitings(Long pubId);
+    Optional<Pub> findPubWithWaitingsAndGuestWaitings(Long pubId);
 
     @Modifying
     @Query("UPDATE Pub p SET p.enterNum = :waitingNum WHERE p.id = :pubId")

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -44,7 +44,8 @@ public class PubService {
     }
 
     public Integer getTotalWaiting(Long pubId) {
-        Pub pub = pubRepository.findPubWithWaitingsAndGuestWaitings(pubId);
+        Pub pub = pubRepository.findPubWithWaitingsAndGuestWaitings(pubId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 주점이 존재하지 않습니다. " + pubId));
         return pub.getGuestWaitingList().size() + pub.getWaitingList().size();
     }
 }

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -42,4 +42,9 @@ public class PubService {
     public void updateEnterNum(Integer waitingNum, Long pubId) {
         pubRepository.incrementEnterNum(waitingNum, pubId);
     }
+
+    public Integer getTotalWaiting(Long pubId) {
+        Pub pub = pubRepository.findPubWithWaitingsAndGuestWaitings(pubId);
+        return pub.getGuestWaitingList().size() + pub.getWaitingList().size();
+    }
 }

--- a/src/main/java/likelion/festival/service/WaitingService.java
+++ b/src/main/java/likelion/festival/service/WaitingService.java
@@ -15,6 +15,7 @@ import likelion.festival.repository.GuestWaitingRepository;
 import likelion.festival.repository.PubRepository;
 import likelion.festival.repository.WaitingRepository;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,7 +86,9 @@ public class WaitingService {
     }
 
     private MyWaitingList convertToDto(Waiting waiting) {
-        Pub pub = pubRepository.findPubWithWaitingsAndGuestWaitings(waiting.getPub().getId());
+        Long pubId = waiting.getPub().getId();
+        Pub pub = pubRepository.findPubWithWaitingsAndGuestWaitings(pubId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 주점이 존재하지 않습니다." + pubId));
         Set<Waiting> pubWaitings = pub.getWaitingList();
         Set<GuestWaiting> pubGuestWaitings = pub.getGuestWaitingList();
 


### PR DESCRIPTION
## 📌 주점의 전체 웨이팅 수만 조회하는 api 추가


---

## 📝 변경사항
- 프론트에서 주점마다 전체 웨이팅 수가 필요하다고 요청했습니다.
- /api/pubs/{pubId}/waiting-count 추가
- 주점의 온라인, 오프라인 웨이팅 리스트를 fetch join하는 쿼리의 반환값을 Optional로 감쌈
- Optional를 활용해 pubId로 주점을 찾지 못 했을 때의 예외 처리 추가

---

## 🔍 테스트 방법
- 명세서에도 작성해놨습니다.

---

## 💬 기타 참고사항
- 추가 설명이 필요하다면 여기에 적어주세요.