### PR TITLE
한 번의 요청으로 모든 주점의 전체 웨이팅 수를 반환, 주점 랭킹 정렬 없이 id로만 정렬해서 반환

### DIFF
--- a/src/main/java/likelion/festival/config/CorsConfig.java
+++ b/src/main/java/likelion/festival/config/CorsConfig.java
@@ -28,6 +28,7 @@ public class CorsConfig {
         configuration.setAllowedMethods(allowedHttpMethods);
 
         configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/likelion/festival/config/SecurityConfig.java
+++ b/src/main/java/likelion/festival/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
             new WhitelistEntry(HttpMethod.POST, "/auth/refresh"),
             new WhitelistEntry(HttpMethod.POST, "/auth/admin-login"),
             new WhitelistEntry(HttpMethod.GET, "/api/lost-items/**"),
-            new WhitelistEntry(HttpMethod.GET, "/api/pubs"),
+            new WhitelistEntry(HttpMethod.GET, "/api/pubs/**"),
             new WhitelistEntry(HttpMethod.POST, "/api/pubs/like"),
             new WhitelistEntry(HttpMethod.GET, "/images/**")
     );

--- a/src/main/java/likelion/festival/controller/PubController.java
+++ b/src/main/java/likelion/festival/controller/PubController.java
@@ -33,10 +33,13 @@ public class PubController {
         return ResponseEntity.ok(pubs);
     }
 
-    @GetMapping("/{pubId}/waiting-count")
-    public ResponseEntity<PubTotalWaitingResponse> getPubTotalWaitingCount(@PathVariable Long pubId) {
-        Integer totalCount = pubService.getTotalWaiting(pubId);
-        PubTotalWaitingResponse response = new PubTotalWaitingResponse(totalCount);
+    @GetMapping("/waiting-count")
+    public ResponseEntity<List<PubTotalWaitingResponse>> getPubTotalWaitingCount() {
+        List<Pub> pubs = pubService.getAllPubs();
+        List<PubTotalWaitingResponse> response =  pubs.stream().map(pub -> new PubTotalWaitingResponse(
+                pub.getId(),
+                pubService.getTotalWaiting(pub.getId())
+        )).toList();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/likelion/festival/dto/PubTotalWaitingResponse.java
+++ b/src/main/java/likelion/festival/dto/PubTotalWaitingResponse.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class PubTotalWaitingResponse {
+    private Long id;
     private Integer waitingCount;
 }

--- a/src/main/java/likelion/festival/repository/PubRepository.java
+++ b/src/main/java/likelion/festival/repository/PubRepository.java
@@ -14,6 +14,9 @@ public interface PubRepository extends JpaRepository<Pub, Long> {
     @Query("SELECT new likelion.festival.dto.PubResponseDto(p.id, p.name ,p.likeCount) FROM Pub p ORDER BY p.likeCount DESC")
     List<PubResponseDto> findAllByOrderByLikeCountDesc();
 
+    @Query("SELECT new likelion.festival.dto.PubResponseDto(p.id, p.name, p.likeCount) FROM Pub p ORDER BY p.id")
+    List<PubResponseDto> findAllOrderById();
+
     Optional<Pub> findByName(String name);
 
     @Query("""

--- a/src/main/java/likelion/festival/service/NcpObjectStorageService.java
+++ b/src/main/java/likelion/festival/service/NcpObjectStorageService.java
@@ -22,7 +22,7 @@ public class NcpObjectStorageService {
 
     public String uploadImage(MultipartFile file) throws IOException {
         String datePath = LocalDate.now().toString();
-        String key = "lost-items/" + datePath + "/" + UUID.randomUUID() + "-" + file.getOriginalFilename();
+        String key = "lost-items/" + datePath + "/" + UUID.randomUUID();
 
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(properties.getBucket())

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -31,6 +31,10 @@ public class PubService {
         return pubRepository.findAllOrderById();
     }
 
+    public List<Pub> getAllPubs() {
+        return pubRepository.findAll();
+    }
+
     @Transactional
     public void addPubLike(Long pubId, Integer addCount) {
         Pub pub = pubRepository.findById(pubId)

--- a/src/main/java/likelion/festival/service/PubService.java
+++ b/src/main/java/likelion/festival/service/PubService.java
@@ -28,7 +28,7 @@ public class PubService {
     }
 
     public List<PubResponseDto> getPubRanks() {
-        return pubRepository.findAllByOrderByLikeCountDesc();
+        return pubRepository.findAllOrderById();
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 한 번의 요청으로 모든 주점의 전체 웨이팅 수를 반환, 주점 랭킹 정렬 없이 id로만 정렬해서 반환


---

## 📝 변경사항
- /api/pubs/{pubId}/waiting -> /api/pubs/waiting으로 변경
- 하나의 주점의 전체 웨이팅 수를 반환 -> 모든 주점의 웨이팅 수를 반환
- /api/pubs -> 주점 순위대로 정렬을 프론트로 넘김

---

## 🔍 테스트 방법
- 예: Postman으로 /login 엔드포인트에 POST 요청 보내기

---

## 💬 기타 참고사항
- 추가 설명이 필요하다면 여기에 적어주세요.