### PR TITLE
스케줄링 알람 코드 추가

### DIFF
--- a/src/main/java/likelion/festival/FestivalApplication.java
+++ b/src/main/java/likelion/festival/FestivalApplication.java
@@ -2,11 +2,16 @@ package likelion.festival;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
+@EnableScheduling
 public class FestivalApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(FestivalApplication.class, args);
 	}
 

--- a/src/main/java/likelion/festival/domain/Concert.java
+++ b/src/main/java/likelion/festival/domain/Concert.java
@@ -1,0 +1,24 @@
+package likelion.festival.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Concert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String artistName;
+
+    @Column(unique = true)
+    private LocalDateTime startTime;
+}

--- a/src/main/java/likelion/festival/repository/ConcertRepository.java
+++ b/src/main/java/likelion/festival/repository/ConcertRepository.java
@@ -1,0 +1,14 @@
+package likelion.festival.repository;
+
+import likelion.festival.domain.Concert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import javax.swing.text.html.Option;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ConcertRepository extends JpaRepository<Concert, Long> {
+
+    Optional<Concert> findByStartTime(LocalDateTime startTime);
+}

--- a/src/main/java/likelion/festival/repository/UserRepository.java
+++ b/src/main/java/likelion/festival/repository/UserRepository.java
@@ -20,4 +20,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     AND c.artistName = :artistName
 """)
     List<String> findAllFcmTokensByArtistName(@Param("artistName") String artistName);
+
+    @Query("""
+    SELECT u.fcmToken 
+    FROM User u
+    WHERE u.fcmToken IS NOT NULL
+""")
+    List<String> findAllFcmTokens();
 }

--- a/src/main/java/likelion/festival/schedule/ConcertScheduleAlarm.java
+++ b/src/main/java/likelion/festival/schedule/ConcertScheduleAlarm.java
@@ -1,0 +1,41 @@
+package likelion.festival.schedule;
+
+import likelion.festival.domain.Concert;
+import likelion.festival.repository.ConcertRepository;
+import likelion.festival.repository.UserRepository;
+import likelion.festival.service.FCMService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ConcertScheduleAlarm {
+    private final ConcertRepository concertRepository;
+    private final FCMService fcmService;
+    private final UserRepository userRepository;
+
+    @Scheduled(fixedRate = 60000)
+    public void notifyConcertUsers() {
+        LocalDateTime now = LocalDateTime.now().withSecond(0).withNano(0);
+        Optional<Concert> concertOpt = concertRepository.findByStartTime(now);
+
+        if (concertOpt.isPresent()) {
+            Concert concert = concertOpt.get();
+            String artistName = concert.getArtistName();
+            List<String> fcmTokens = userRepository.findAllFcmTokensByArtistName(artistName);
+            for (String token : fcmTokens) {
+                fcmService.sendFcmMessage(
+                        token,
+                        artistName + " 공연이 시작됩니다!",
+                        "지금 바로 확인하세요!"
+                );
+            }
+        }
+    }
+}
+

--- a/src/main/java/likelion/festival/schedule/PubOpenAlarmService.java
+++ b/src/main/java/likelion/festival/schedule/PubOpenAlarmService.java
@@ -15,8 +15,48 @@ public class PubOpenAlarmService {
     private final UserRepository userRepository;
     private final FCMService fcmService;
 
+    // 테스트 용으로 매일 오후 5시 알림보냄, 실제 배포에는 삭제 요망
     @Scheduled(cron = "0 0 17 * * *", zone = "Asia/Seoul")
     public void openAlarm() {
+        List<String> fcmTokenList = userRepository.findAllFcmTokens();
+
+        for (String token : fcmTokenList) {
+            fcmService.sendFcmMessage(
+                    token,
+                    "한양대 에리카 봄 축제",
+                    "주점들이 오픈했습니다! 저희 어플에서 메뉴판과 웨이팅까지 이용해보세요!"
+            );
+        }
+    }
+
+    @Scheduled(cron = "0 0 17 28 5 *", zone = "Asia/Seoul")
+    public void openAlarm1() {
+        List<String> fcmTokenList = userRepository.findAllFcmTokens();
+
+        for (String token : fcmTokenList) {
+            fcmService.sendFcmMessage(
+                    token,
+                    "한양대 에리카 봄 축제",
+                    "주점들이 오픈했습니다! 저희 어플에서 메뉴판과 웨이팅까지 이용해보세요!"
+            );
+        }
+    }
+
+    @Scheduled(cron = "0 0 17 29 5 *", zone = "Asia/Seoul")
+    public void openAlarm2() {
+        List<String> fcmTokenList = userRepository.findAllFcmTokens();
+
+        for (String token : fcmTokenList) {
+            fcmService.sendFcmMessage(
+                    token,
+                    "한양대 에리카 봄 축제",
+                    "주점들이 오픈했습니다! 저희 어플에서 메뉴판과 웨이팅까지 이용해보세요!"
+            );
+        }
+    }
+
+    @Scheduled(cron = "0 0 17 30 5 *", zone = "Asia/Seoul")
+    public void openAlarm3() {
         List<String> fcmTokenList = userRepository.findAllFcmTokens();
 
         for (String token : fcmTokenList) {

--- a/src/main/java/likelion/festival/schedule/PubOpenAlarmService.java
+++ b/src/main/java/likelion/festival/schedule/PubOpenAlarmService.java
@@ -1,0 +1,30 @@
+package likelion.festival.schedule;
+
+import likelion.festival.repository.UserRepository;
+import likelion.festival.service.FCMService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PubOpenAlarmService {
+
+    private final UserRepository userRepository;
+    private final FCMService fcmService;
+
+    @Scheduled(cron = "0 0 17 * * *", zone = "Asia/Seoul")
+    public void openAlarm() {
+        List<String> fcmTokenList = userRepository.findAllFcmTokens();
+
+        for (String token : fcmTokenList) {
+            fcmService.sendFcmMessage(
+                    token,
+                    "한양대 에리카 봄 축제",
+                    "주점들이 오픈했습니다! 저희 어플에서 메뉴판과 웨이팅까지 이용해보세요!"
+            );
+        }
+    }
+}

--- a/src/main/java/likelion/festival/schedule/PubOpenAlarmService.java
+++ b/src/main/java/likelion/festival/schedule/PubOpenAlarmService.java
@@ -24,7 +24,7 @@ public class PubOpenAlarmService {
             fcmService.sendFcmMessage(
                     token,
                     "한양대 에리카 봄 축제",
-                    "주점들이 오픈했습니다! 저희 어플에서 메뉴판과 웨이팅까지 이용해보세요!"
+                    "주점들이 오픈했습니다! 테스트용 주점 알림입니다"
             );
         }
     }


### PR DESCRIPTION
## 📌 스케줄링 알람 코드 추가


---

## 📝 변경사항
- 공연 엔티티 추가
- 매 분마다 체크하다가 공연 시간이 되면 유저들에게 알림 보내는 로직
- 축제 날에 오후 5시에는 주점 오픈 알림 보내는 로직 추가

---

## 🔍 테스트 방법


---

## 💬 기타 참고사항